### PR TITLE
Infra cleaning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @timotheeguerin @iscai-msft

--- a/package.json
+++ b/package.json
@@ -45,5 +45,8 @@
     "syncpack": "^8.2.4",
     "ts-jest": "^28.0.5",
     "typescript": "^4.7.4"
+  },
+  "syncpack": {
+    "workspace": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "engines": {
     "node": ">=16.0.0",
-    "pnpm": ">=7.5.2"
+    "pnpm": ">=7.6.0"
   },
   "repository": {
     "type": "git",

--- a/packages/cadl-ranch-api/package.json
+++ b/packages/cadl-ranch-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch-api",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cadl Ranch set of api to implement mock api",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/cadl-ranch-expect/package.json
+++ b/packages/cadl-ranch-expect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch-expect",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cadl Library providing decorator and validation for Cadl Ranch specs",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/cadl-ranch-specs/http/extensible-enums/main.cadl
+++ b/packages/cadl-ranch-specs/http/extensible-enums/main.cadl
@@ -5,12 +5,11 @@ import "@azure-tools/cadl-ranch-expect";
 using Cadl.Http;
 using Azure.Core.Foundations;
 
-@serviceTitle("PetStoreInc")
+@serviceTitle("ExtensibleEnums")
 @serviceVersion("1.0.0")
 @server("http://localhost:3000", "TestServer endpoint")
-@doc("PetStore")
 @route("/extensible-enums")
-namespace Cadl.TestServer.ExtensibleEnums;
+namespace ExtensibleEnums;
 
 enum DaysOfWeekExtensibleEnumValues {
   "Monday",

--- a/packages/cadl-ranch-specs/package.json
+++ b/packages/cadl-ranch-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch-specs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cadl scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/cadl-ranch-specs/package.json
+++ b/packages/cadl-ranch-specs/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/Azure/cadl-ranch#readme",
   "dependencies": {
-    "@azure-tools/cadl-ranch": "0.1.1",
-    "@azure-tools/cadl-ranch-api": "0.1.1"
+    "@azure-tools/cadl-ranch": "workspace:~",
+    "@azure-tools/cadl-ranch-api": "workspace:~"
   },
   "devDependencies": {
     "@cadl-lang/eslint-config-cadl": "^0.3.0",
@@ -42,7 +42,7 @@
   },
   "peerDependencies": {
     "@azure-tools/cadl-autorest": "0.19.0",
-    "@azure-tools/cadl-ranch-expect": "0.1.1",
+    "@azure-tools/cadl-ranch-expect": "workspace:~",
     "@azure-tools/cadl-azure-core": "~0.6.0",
     "@cadl-lang/compiler": "~0.34.0",
     "@cadl-lang/openapi3": "0.14.0",

--- a/packages/cadl-ranch/package.json
+++ b/packages/cadl-ranch/package.json
@@ -29,8 +29,10 @@
   },
   "homepage": "https://github.com/Azure/cadl-ranch#readme",
   "dependencies": {
-    "@azure-tools/cadl-ranch-api": "0.1.1",
-    "@azure-tools/cadl-ranch-expect": "0.1.1",
+    "@azure-tools/cadl-ranch-api": "workspace:~",
+    "@azure-tools/cadl-ranch-expect": "workspace:~",
+    "@cadl-lang/compiler": "~0.34.0",
+    "@cadl-lang/rest": "~0.16.0",
     "body-parser": "^1.20.0",
     "deep-equal": "^2.0.5",
     "express": "^4.18.1",
@@ -57,9 +59,5 @@
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "typescript": "^4.7.4"
-  },
-  "peerDependencies": {
-    "@cadl-lang/compiler": "~0.34.0",
-    "@cadl-lang/rest": "~0.16.0"
   }
 }

--- a/packages/cadl-ranch/package.json
+++ b/packages/cadl-ranch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cadl Ranch Tool to validate, run mock api, collect coverage.",
   "main": "dist/index.js",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,12 +136,15 @@ importers:
 
   packages/cadl-ranch-expect:
     specifiers:
+      '@cadl-lang/compiler': ~0.34.0
       '@cadl-lang/eslint-config-cadl': ^0.3.0
       '@types/node': ^18.0.6
       eslint: ^8.20.0
       prettier: ^2.7.1
       rimraf: ^3.0.2
       typescript: ^4.7.4
+    dependencies:
+      '@cadl-lang/compiler': 0.34.0
     devDependencies:
       '@cadl-lang/eslint-config-cadl': 0.3.0_prettier@2.7.1
       '@types/node': 18.7.6
@@ -152,17 +155,33 @@ importers:
 
   packages/cadl-ranch-specs:
     specifiers:
+      '@azure-tools/cadl-autorest': 0.19.0
+      '@azure-tools/cadl-azure-core': ~0.6.0
       '@azure-tools/cadl-ranch': workspace:~
       '@azure-tools/cadl-ranch-api': workspace:~
+      '@azure-tools/cadl-ranch-expect': workspace:~
+      '@cadl-lang/compiler': ~0.34.0
       '@cadl-lang/eslint-config-cadl': ^0.3.0
+      '@cadl-lang/openapi': 0.11.0
+      '@cadl-lang/openapi3': 0.14.0
+      '@cadl-lang/rest': ~0.16.0
+      '@cadl-lang/versioning': ~0.7.0
       '@types/node': ^18.0.6
       eslint: ^8.20.0
       prettier: ^2.7.1
       rimraf: ^3.0.2
       typescript: ^4.7.4
     dependencies:
+      '@azure-tools/cadl-autorest': 0.19.0_7cfyjcwao5tn26di3qzzxztvsy
+      '@azure-tools/cadl-azure-core': 0.6.0_jwnjv33kln7n6m6w5v66qlatxq
       '@azure-tools/cadl-ranch': link:../cadl-ranch
       '@azure-tools/cadl-ranch-api': link:../cadl-ranch-api
+      '@azure-tools/cadl-ranch-expect': link:../cadl-ranch-expect
+      '@cadl-lang/compiler': 0.34.0
+      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
+      '@cadl-lang/openapi3': 0.14.0_gbhzcnt65o4hn4fgs3un4azdlm
+      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
+      '@cadl-lang/versioning': 0.7.0
     devDependencies:
       '@cadl-lang/eslint-config-cadl': 0.3.0_prettier@2.7.1
       '@types/node': 18.7.6
@@ -180,6 +199,36 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.15
     dev: true
+
+  /@azure-tools/cadl-autorest/0.19.0_7cfyjcwao5tn26di3qzzxztvsy:
+    resolution: {integrity: sha512-lu9eDwwBHi11bcVKH/4p6qgtUdnxhqgNT9fsoweXWPlzSMpNbmHxenpJ0iUhRc5q2+KiKwEMO+1cDiZLnpM6/g==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@azure-tools/cadl-azure-core': ~0.6.0
+      '@cadl-lang/compiler': ~0.34.0
+      '@cadl-lang/openapi': ~0.11.0
+      '@cadl-lang/rest': ~0.16.0
+      '@cadl-lang/versioning': ~0.7.0
+    dependencies:
+      '@azure-tools/cadl-azure-core': 0.6.0_jwnjv33kln7n6m6w5v66qlatxq
+      '@cadl-lang/compiler': 0.34.0
+      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
+      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
+      '@cadl-lang/versioning': 0.7.0
+    dev: false
+
+  /@azure-tools/cadl-azure-core/0.6.0_jwnjv33kln7n6m6w5v66qlatxq:
+    resolution: {integrity: sha512-IQVy1oAACCJAu4yJylEnZzdkc7P+5soqUsqe5+L1b0/WIKuBt8vgioESlE7LivX9BBNIPIMjmEKk5rcCZ7KTDQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@cadl-lang/compiler': ~0.34.0
+      '@cadl-lang/openapi': ~0.11.0
+      '@cadl-lang/rest': ~0.16.0
+    dependencies:
+      '@cadl-lang/compiler': 0.34.0
+      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
+      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
+    dev: false
 
   /@babel/code-frame/7.16.7:
     resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
@@ -544,6 +593,32 @@ packages:
       - supports-color
     dev: true
 
+  /@cadl-lang/openapi/0.11.0_b4gh4y54qtrwf4tvxw5tu2myii:
+    resolution: {integrity: sha512-miVNnGNq1VOdirTEStKIi00AMxPi/C53bGizrdqBUS7ZJ1vDQR7pq9hbPNYX8K7qAjMMSrJQykZc0xTOB/Jlow==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@cadl-lang/compiler': ~0.34.0
+      '@cadl-lang/rest': ~0.16.0
+    dependencies:
+      '@cadl-lang/compiler': 0.34.0
+      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
+    dev: false
+
+  /@cadl-lang/openapi3/0.14.0_gbhzcnt65o4hn4fgs3un4azdlm:
+    resolution: {integrity: sha512-NLNeVIBFmpy3KNy1T8coftynVLOUOk4HBWYtqsaciEkrbAGRbJrNfzbC42mRGqr/yBD6Iyo03B5V3H1pKcAyEA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@cadl-lang/compiler': ~0.34.0
+      '@cadl-lang/openapi': ~0.11.0
+      '@cadl-lang/rest': ~0.16.0
+      '@cadl-lang/versioning': ~0.7.0
+    dependencies:
+      '@cadl-lang/compiler': 0.34.0
+      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
+      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
+      '@cadl-lang/versioning': 0.7.0
+    dev: false
+
   /@cadl-lang/prettier-plugin-cadl/0.5.14:
     resolution: {integrity: sha512-02ZKdt/8BPA3kzct+4lBQkTVAsq3cze6SMq5JD+ICui1MyoLsS2ICoqNBU6SaEsug+0mkOuvAZCia0V1v7L93Q==}
     dependencies:
@@ -555,6 +630,13 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@cadl-lang/compiler': ~0.34.0
+    dependencies:
+      '@cadl-lang/compiler': 0.34.0
+    dev: false
+
+  /@cadl-lang/versioning/0.7.0:
+    resolution: {integrity: sha512-Wg0CyP47jZnv4hHaq8enUxhsqaJSQzYrlzQzg265CtZrUFzwlBAkqQVel8qeA6f/wljkkL5Se75Vt5tLE2kfhQ==}
+    engines: {node: '>=16.0.0'}
     dependencies:
       '@cadl-lang/compiler': 0.34.0
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ importers:
 
   packages/cadl-ranch:
     specifiers:
-      '@azure-tools/cadl-ranch-api': 0.1.1
-      '@azure-tools/cadl-ranch-expect': 0.1.1
+      '@azure-tools/cadl-ranch-api': workspace:~
+      '@azure-tools/cadl-ranch-expect': workspace:~
       '@cadl-lang/compiler': ~0.34.0
       '@cadl-lang/eslint-config-cadl': ^0.3.0
       '@cadl-lang/rest': ~0.16.0
@@ -136,15 +136,12 @@ importers:
 
   packages/cadl-ranch-expect:
     specifiers:
-      '@cadl-lang/compiler': ~0.34.0
       '@cadl-lang/eslint-config-cadl': ^0.3.0
       '@types/node': ^18.0.6
       eslint: ^8.20.0
       prettier: ^2.7.1
       rimraf: ^3.0.2
       typescript: ^4.7.4
-    dependencies:
-      '@cadl-lang/compiler': 0.34.0
     devDependencies:
       '@cadl-lang/eslint-config-cadl': 0.3.0_prettier@2.7.1
       '@types/node': 18.7.6
@@ -155,33 +152,17 @@ importers:
 
   packages/cadl-ranch-specs:
     specifiers:
-      '@azure-tools/cadl-autorest': 0.19.0
-      '@azure-tools/cadl-azure-core': ~0.6.0
-      '@azure-tools/cadl-ranch': 0.1.1
-      '@azure-tools/cadl-ranch-api': 0.1.1
-      '@azure-tools/cadl-ranch-expect': 0.1.1
-      '@cadl-lang/compiler': ~0.34.0
+      '@azure-tools/cadl-ranch': workspace:~
+      '@azure-tools/cadl-ranch-api': workspace:~
       '@cadl-lang/eslint-config-cadl': ^0.3.0
-      '@cadl-lang/openapi': 0.11.0
-      '@cadl-lang/openapi3': 0.14.0
-      '@cadl-lang/rest': ~0.16.0
-      '@cadl-lang/versioning': ~0.7.0
       '@types/node': ^18.0.6
       eslint: ^8.20.0
       prettier: ^2.7.1
       rimraf: ^3.0.2
       typescript: ^4.7.4
     dependencies:
-      '@azure-tools/cadl-autorest': 0.19.0_7cfyjcwao5tn26di3qzzxztvsy
-      '@azure-tools/cadl-azure-core': 0.6.0_jwnjv33kln7n6m6w5v66qlatxq
       '@azure-tools/cadl-ranch': link:../cadl-ranch
       '@azure-tools/cadl-ranch-api': link:../cadl-ranch-api
-      '@azure-tools/cadl-ranch-expect': link:../cadl-ranch-expect
-      '@cadl-lang/compiler': 0.34.0
-      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
-      '@cadl-lang/openapi3': 0.14.0_gbhzcnt65o4hn4fgs3un4azdlm
-      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
-      '@cadl-lang/versioning': 0.7.0
     devDependencies:
       '@cadl-lang/eslint-config-cadl': 0.3.0_prettier@2.7.1
       '@types/node': 18.7.6
@@ -199,36 +180,6 @@ packages:
       '@jridgewell/gen-mapping': 0.1.1
       '@jridgewell/trace-mapping': 0.3.15
     dev: true
-
-  /@azure-tools/cadl-autorest/0.19.0_7cfyjcwao5tn26di3qzzxztvsy:
-    resolution: {integrity: sha512-lu9eDwwBHi11bcVKH/4p6qgtUdnxhqgNT9fsoweXWPlzSMpNbmHxenpJ0iUhRc5q2+KiKwEMO+1cDiZLnpM6/g==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@azure-tools/cadl-azure-core': ~0.6.0
-      '@cadl-lang/compiler': ~0.34.0
-      '@cadl-lang/openapi': ~0.11.0
-      '@cadl-lang/rest': ~0.16.0
-      '@cadl-lang/versioning': ~0.7.0
-    dependencies:
-      '@azure-tools/cadl-azure-core': 0.6.0_jwnjv33kln7n6m6w5v66qlatxq
-      '@cadl-lang/compiler': 0.34.0
-      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
-      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
-      '@cadl-lang/versioning': 0.7.0
-    dev: false
-
-  /@azure-tools/cadl-azure-core/0.6.0_jwnjv33kln7n6m6w5v66qlatxq:
-    resolution: {integrity: sha512-IQVy1oAACCJAu4yJylEnZzdkc7P+5soqUsqe5+L1b0/WIKuBt8vgioESlE7LivX9BBNIPIMjmEKk5rcCZ7KTDQ==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@cadl-lang/compiler': ~0.34.0
-      '@cadl-lang/openapi': ~0.11.0
-      '@cadl-lang/rest': ~0.16.0
-    dependencies:
-      '@cadl-lang/compiler': 0.34.0
-      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
-      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
-    dev: false
 
   /@babel/code-frame/7.16.7:
     resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
@@ -593,32 +544,6 @@ packages:
       - supports-color
     dev: true
 
-  /@cadl-lang/openapi/0.11.0_b4gh4y54qtrwf4tvxw5tu2myii:
-    resolution: {integrity: sha512-miVNnGNq1VOdirTEStKIi00AMxPi/C53bGizrdqBUS7ZJ1vDQR7pq9hbPNYX8K7qAjMMSrJQykZc0xTOB/Jlow==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@cadl-lang/compiler': ~0.34.0
-      '@cadl-lang/rest': ~0.16.0
-    dependencies:
-      '@cadl-lang/compiler': 0.34.0
-      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
-    dev: false
-
-  /@cadl-lang/openapi3/0.14.0_gbhzcnt65o4hn4fgs3un4azdlm:
-    resolution: {integrity: sha512-NLNeVIBFmpy3KNy1T8coftynVLOUOk4HBWYtqsaciEkrbAGRbJrNfzbC42mRGqr/yBD6Iyo03B5V3H1pKcAyEA==}
-    engines: {node: '>=16.0.0'}
-    peerDependencies:
-      '@cadl-lang/compiler': ~0.34.0
-      '@cadl-lang/openapi': ~0.11.0
-      '@cadl-lang/rest': ~0.16.0
-      '@cadl-lang/versioning': ~0.7.0
-    dependencies:
-      '@cadl-lang/compiler': 0.34.0
-      '@cadl-lang/openapi': 0.11.0_b4gh4y54qtrwf4tvxw5tu2myii
-      '@cadl-lang/rest': 0.16.0_@cadl-lang+compiler@0.34.0
-      '@cadl-lang/versioning': 0.7.0
-    dev: false
-
   /@cadl-lang/prettier-plugin-cadl/0.5.14:
     resolution: {integrity: sha512-02ZKdt/8BPA3kzct+4lBQkTVAsq3cze6SMq5JD+ICui1MyoLsS2ICoqNBU6SaEsug+0mkOuvAZCia0V1v7L93Q==}
     dependencies:
@@ -630,13 +555,6 @@ packages:
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@cadl-lang/compiler': ~0.34.0
-    dependencies:
-      '@cadl-lang/compiler': 0.34.0
-    dev: false
-
-  /@cadl-lang/versioning/0.7.0:
-    resolution: {integrity: sha512-Wg0CyP47jZnv4hHaq8enUxhsqaJSQzYrlzQzg265CtZrUFzwlBAkqQVel8qeA6f/wljkkL5Se75Vt5tLE2kfhQ==}
-    engines: {node: '>=16.0.0'}
     dependencies:
       '@cadl-lang/compiler': 0.34.0
     dev: false


### PR DESCRIPTION
- Use `workspace:~` for internal package versions. Makes it easier to bump.
- Fix some specs
- Add owners
- Make pnpm minimum version `7.6.0` as this is where `auto-install-peers` was addded