### PR TITLE
migrate bodycomplex in autorest.testserver (for complex polymorphism and dictionary)

### DIFF
--- a/packages/cadl-ranch-specs/http/README.md
+++ b/packages/cadl-ranch-specs/http/README.md
@@ -25,3 +25,5 @@ The tests in the http/models directory describe scenarios for generating models 
 - [nested-models](https://github.com/Azure/cadl-ranch/tree/main/packages/cadl-ranch-specs/http/models/nested-models) - Generate, send, and receive input, output, and round-trip models with required nested model properties.
 - [readonly-properties](https://github.com/Azure/cadl-ranch/tree/main/packages/cadl-ranch-specs/http/models/readonly-properties) - Generate, send, and receive input, output, and round-trip models with readonly properties.
 - [inheritance](https://github.com/Azure/cadl-ranch/tree/main/packages/cadl-ranch-specs/http/models/inheritance) - Generate, send, and receive round-trip models polymorphic models.
+- [inheritance-complex](https://github.com/Azure/cadl-ranch/tree/main/packages/cadl-ranch-specs/http/models/inheritance-complex) - Generate, send, and receive complex polymorphic models.
+- [dictionary](https://github.com/Azure/cadl-ranch/tree/main/packages/cadl-ranch-specs/http/models/dictionary) - Generate, send, and receive dictionary properties.

--- a/packages/cadl-ranch-specs/http/models/dictionary/main.cadl
+++ b/packages/cadl-ranch-specs/http/models/dictionary/main.cadl
@@ -1,0 +1,57 @@
+import "@azure-tools/cadl-azure-core";
+import "@azure-tools/cadl-ranch-expect";
+
+using Cadl.Http;
+using Azure.Core.Foundations;
+
+@serviceTitle("Dictionary in Complex Test Service")
+@serviceVersion("2016-02-29")
+@server("http://localhost:3000", "Testserver endpoint")
+@doc("Illustrates complex model generation, as well as serialization and deserialization.")
+namespace Cadl.Testserver.BodyComplexDictionary;
+
+model dictionary_wrapper {
+  defaultProgram?: Record<string>;
+}
+
+@scenario
+@route("/complex/dictionary/typed")
+namespace dictionary {
+  @route("/valid")
+  @scenarioDoc("Get complex types with dictionary properties")
+  @get
+  op getValid(): dictionary_wrapper | ErrorResponse;
+
+  @route("/valid")
+  @scenarioDoc("Put complex types with dictionary properties")
+  @put
+  op putValid(
+    @doc("Please put a dictionary with 5 key-value pairs: \"txt\":\"notepad\", \"bmp\":\"mspaint\", \"xls\":\"excel\", \"exe\":\"\", \"\":null")
+    @body
+    complexBody: dictionary_wrapper
+  ): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+
+  @route("/empty")
+  @scenarioDoc("Get complex types with dictionary property which is empty")
+  @get
+  op getEmpty(): dictionary_wrapper | ErrorResponse;
+
+  @route("/empty")
+  @scenarioDoc("Put complex types with dictionary properties which is empty")
+  @put
+  op putEmpty(@doc("Please put an empty dictionary") @body complexBody: dictionary_wrapper): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+
+  @route("/null")
+  @scenarioDoc("Get complex types with dictionary property which is null")
+  @get
+  op getNull(): dictionary_wrapper | ErrorResponse;
+
+  @route("/notprovided")
+  @scenarioDoc("Get complex types with dictionary property while server doesn't provide a response payload")
+  @get
+  op getNotProvided(): dictionary_wrapper | ErrorResponse;
+}

--- a/packages/cadl-ranch-specs/http/models/dictionary/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/models/dictionary/mockapi.ts
@@ -1,0 +1,42 @@
+import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+import * as _ from "underscore";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+/**
+ * Put and get for typed dictionary properties.
+ */
+const dictionaryValidBody = '{"defaultProgram":{"txt":"notepad","bmp":"mspaint","xls":"excel","exe":"","":null}}';
+Scenarios.Dictionary_put = passOnSuccess(
+  mockapi.put("/complex/dictionary/typed/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      req.expect.bodyEquals(JSON.parse(dictionaryValidBody));
+      return { status: 200 };
+    } else if (req.params.scenario === "empty") {
+      if (JSON.stringify(req.body) === '{"defaultProgram":{}}') {
+        return { status: 200 };
+      } else {
+        throw new ValidationError("Did not like complex dictionary req ", { defaultProgram: {} }, req.body);
+      }
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);
+
+Scenarios.Dictionary_get = passOnSuccess(
+  mockapi.get("/complex/dictionary/typed/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      return { status: 200, body: json(JSON.parse(dictionaryValidBody)) };
+    } else if (req.params.scenario === "empty") {
+      return { status: 200, body: json(JSON.parse('{"defaultProgram":{}}')) };
+    } else if (req.params.scenario === "null") {
+      return { status: 200, body: json(JSON.parse('{"defaultProgram":null}')) };
+    } else if (req.params.scenario === "notprovided") {
+      return { status: 200, body: json(JSON.parse("{}")) };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);

--- a/packages/cadl-ranch-specs/http/models/inheritance-complex/README.md
+++ b/packages/cadl-ranch-specs/http/models/inheritance-complex/README.md
@@ -1,0 +1,7 @@
+The inheritance-complex test cases cover input and output of conditions:
+
+- three level inheritances with no discriminator. (pet->cat->siamese)
+- three level inheritances with discriminators. (Fish->shark->sawshark)
+- collection of instances (cat.hates, Fish.siblings).
+- recursive three level polymorphic models. (Fish.siblings)
+- how is the serialization/deserialization when missing discriminator in models

--- a/packages/cadl-ranch-specs/http/models/inheritance-complex/main.cadl
+++ b/packages/cadl-ranch-specs/http/models/inheritance-complex/main.cadl
@@ -1,0 +1,256 @@
+import "@cadl-lang/rest";
+import "@azure-tools/cadl-azure-core";
+import "@azure-tools/cadl-ranch-expect";
+
+using Cadl.Rest;
+using Cadl.Http;
+using Azure.Core.Foundations;
+
+@serviceTitle("Polymorphism in Complex Test Service")
+@serviceVersion("2016-02-29")
+@server("http://localhost:3000", "Testserver endpoint")
+@doc("Illustrates complex model generation, as well as serialization and deserialization.")
+namespace Cadl.Testserver.BodyComplexPolymorphism;
+
+@knownValues(CMYKColorsValues)
+model CMYKColors is string {}
+
+enum CMYKColorsValues {
+  cyan,
+  Magenta,
+  YELLOW,
+  blacK,
+}
+
+model basic {
+  @doc("Basic Id")
+  id?: int32;
+
+  @doc("Name property with a very long description that does not fit on a single line and a line break.")
+  name?: string;
+  color?: CMYKColors;
+}
+
+model pet {
+  id?: int32;
+  name?: string;
+}
+
+model cat extends pet {
+  color?: string;
+  hates?: dog[];
+}
+
+model siamese extends cat {
+  breed?: string;
+}
+
+model dog extends pet {
+  food?: string;
+}
+
+@discriminator("fish_type")
+model DotFish {
+  species?: string;
+}
+
+model DotSalmon extends DotFish {
+  fish_type: "DotSalmon";
+  location?: string;
+  iswild?: boolean;
+}
+
+model DotFishMarket {
+  sampleSalmon?: DotSalmon;
+  salmons?: DotSalmon[];
+  sampleFish?: DotFish;
+  fishes: DotFish[];
+}
+
+@discriminator("fishtype")
+model Fish {
+  species?: string;
+  length: float32;
+  siblings?: Fish[];
+}
+
+model salmon extends Fish {
+  fishtype: "salmon";
+  location?: string;
+  iswild?: boolean;
+}
+
+model smart_salmon extends Fish {
+  fishtype: "smart_salmon";
+  college_degree?: string;
+}
+
+@discriminator("sharktype")
+model shark extends Fish {
+  fishtype: "shark";
+  age?: int32;
+  birthday: zonedDateTime;
+}
+
+model sawshark extends shark {
+  sharktype: "sawshark";
+  picture?: bytes;
+}
+
+@doc("Colors possible")
+@knownValues(GoblinSharkColorValues)
+model GoblinSharkColor is string {}
+
+enum GoblinSharkColorValues {
+  pink,
+  gray,
+  brown,
+
+  @doc("Uppercase RED")
+  upperRed: "RED",
+
+  @doc("Lowercase RED")
+  lowerRed: "red",
+}
+
+model goblinshark extends shark {
+  sharktype: "goblin";
+  jawsize?: int32;
+  color?: GoblinSharkColor = "gray";
+}
+
+model cookiecuttershark extends shark {
+  sharktype: "cookiecuttershark";
+}
+
+@scenario
+@route("/complex/basic")
+namespace basicOps {
+  @route("/valid")
+  @scenarioDoc("Get complex type {id: 2, name: 'abc', color: 'YELLOW'}")
+  @get
+  op getValid(): basic | ErrorResponse;
+
+  @route("/valid")
+  @scenarioDoc("Please put {id: 2, name: 'abc', color: 'Magenta'}")
+  @put
+  op putValid(@header "api-version": string, @body complexBody: basic): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+
+  @route("/invalid")
+  @scenarioDoc("Get a basic complex type that is invalid for the local strong type")
+  @get
+  op getInvalid(): basic | ErrorResponse;
+
+  @route("/empty")
+  @scenarioDoc("Get a basic complex type that is empty")
+  @get
+  op getEmpty(): basic | ErrorResponse;
+
+  @route("/null")
+  @scenarioDoc("Get a basic complex type whose properties are null")
+  @get
+  op getNull(): basic | ErrorResponse;
+
+  @route("/notprovided")
+  @scenarioDoc("Get a basic complex type whose properties are null")
+  @get
+  op getNotProvided(): basic | ErrorResponse;
+}
+
+@route("/complex/inheritance/valid")
+namespace inheritance {
+  @scenarioDoc("Get complex types that extend others")
+  @get
+  op getValid(): siamese | ErrorResponse;
+
+  @scenarioDoc("Put complex types that extend others")
+  @put
+  op putValid(
+    @doc("Please put a siamese with id=2, name=\"Siameee\", color=green, breed=persion, which hates 2 dogs, the 1st one named \"Potato\" with id=1 and food=\"tomato\", and the 2nd one named \"Tomato\" with id=-1 and food=\"french fries\".")
+    @body
+    complexBody: siamese
+  ): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+}
+
+@route("/complex/polymorphism")
+namespace polymorphism {
+  @route("/valid")
+  @scenarioDoc("Get complex types that are polymorphic")
+  @get
+  op getValid(): Fish | ErrorResponse;
+
+  @route("/valid")
+  @scenarioDoc("Put complex types that are polymorphic")
+  @put
+  op putValid(
+    @doc("Please put a salmon that looks like this:\n{\n        'fishtype':'Salmon',\n        'location':'alaska',\n        'iswild':true,\n        'species':'king',\n        'length':1.0,\n        'siblings':[\n          {\n            'fishtype':'Shark',\n            'age':6,\n            'birthday': '2012-01-05T01:00:00Z',\n            'length':20.0,\n            'species':'predator',\n          },\n          {\n            'fishtype':'Sawshark',\n            'age':105,\n            'birthday': '1900-01-05T01:00:00Z',\n            'length':10.0,\n            'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),\n            'species':'dangerous',\n          },\n          {\n            'fishtype': 'goblin',\n            'age': 1,\n            'birthday': '2015-08-08T00:00:00Z',\n            'length': 30.0,\n            'species': 'scary',\n            'jawsize': 5\n          }\n        ]\n      };")
+    @body
+    complexBody: Fish
+  ): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+
+  @route("/dotsyntax")
+  @scenarioDoc("Get complex types that are polymorphic, JSON key contains a dot")
+  @get
+  op getDotSyntax(): DotFish | ErrorResponse;
+
+  @route("/composedWithDiscriminator")
+  @scenarioDoc("Get complex object composing a polymorphic scalar property and array property with polymorphic element type, with discriminator specified. Deserialization must NOT fail and use the discriminator type specified on the wire.")
+  @get
+  op getComposedWithDiscriminator(): DotFishMarket | ErrorResponse;
+
+  @route("/composedWithoutDiscriminator")
+  @scenarioDoc("Get complex object composing a polymorphic scalar property and array property with polymorphic element type, without discriminator specified on wire. Deserialization must NOT fail and use the explicit type of the property.")
+  @get
+  op getComposedWithoutDiscriminator(): DotFishMarket | ErrorResponse;
+
+  @route("/complicated")
+  @scenarioDoc("Get complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties")
+  @get
+  op getComplicated(): Fish | ErrorResponse;
+
+  @route("/complicated")
+  @scenarioDoc("Put complex types that are polymorphic, but not at the root of the hierarchy; also have additional properties")
+  @put
+  op putComplicated(@body complexBody: Fish): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+
+  @route("/missingdiscriminator")
+  @scenarioDoc("Put complex types that are polymorphic, omitting the discriminator")
+  @put
+  op putMissingDiscriminator(@body complexBody: salmon): salmon | ErrorResponse;
+
+  @route("/missingrequired/invalid")
+  @scenarioDoc("Put complex types that are polymorphic, attempting to omit required 'birthday' field - the request should not be allowed from the client")
+  @put
+  op putValidMissingRequired(
+    @doc("Please attempt put a sawshark that looks like this, the client should not allow this data to be sent:\n{\n    \"fishtype\": \"sawshark\",\n    \"species\": \"snaggle toothed\",\n    \"length\": 18.5,\n    \"age\": 2,\n    \"birthday\": \"2013-06-01T01:00:00Z\",\n    \"location\": \"alaska\",\n    \"picture\": base64(FF FF FF FF FE),\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"birthday\": \"2012-01-05T01:00:00Z\",\n            \"length\": 20,\n            \"age\": 6\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"picture\": base64(FF FF FF FF FE),\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}")
+    @body
+    complexBody: Fish
+  ): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+}
+
+@route("/complex/polymorphicrecursive/valid")
+namespace polymorphicrecursive {
+  @scenarioDoc("Get complex types that are polymorphic and have recursive references")
+  @get
+  op getValid(): Fish | ErrorResponse;
+
+  @scenarioDoc("Put complex types that are polymorphic and have recursive references")
+  @put
+  op putValid(
+    @doc("Please put a salmon that looks like this:\n{\n    \"fishtype\": \"salmon\",\n    \"species\": \"king\",\n    \"length\": 1,\n    \"age\": 1,\n    \"location\": \"alaska\",\n    \"iswild\": true,\n    \"siblings\": [\n        {\n            \"fishtype\": \"shark\",\n            \"species\": \"predator\",\n            \"length\": 20,\n            \"age\": 6,\n            \"siblings\": [\n                {\n                    \"fishtype\": \"salmon\",\n                    \"species\": \"coho\",\n                    \"length\": 2,\n                    \"age\": 2,\n                    \"location\": \"atlantic\",\n                    \"iswild\": true,\n                    \"siblings\": [\n                        {\n                            \"fishtype\": \"shark\",\n                            \"species\": \"predator\",\n                            \"length\": 20,\n                            \"age\": 6\n                        },\n                        {\n                            \"fishtype\": \"sawshark\",\n                            \"species\": \"dangerous\",\n                            \"length\": 10,\n                            \"age\": 105\n                        }\n                    ]\n                },\n                {\n                    \"fishtype\": \"sawshark\",\n                    \"species\": \"dangerous\",\n                    \"length\": 10,\n                    \"age\": 105\n                }\n            ]\n        },\n        {\n            \"fishtype\": \"sawshark\",\n            \"species\": \"dangerous\",\n            \"length\": 10,\n            \"age\": 105\n        }\n    ]\n}")
+    @body
+    complexBody: Fish
+  ): {
+    @statusCode statusCode: 200;
+  } | ErrorResponse;
+}

--- a/packages/cadl-ranch-specs/http/models/inheritance-complex/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/models/inheritance-complex/mockapi.ts
@@ -1,0 +1,460 @@
+import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+function coerceDate(targetObject: any) {
+  let stringRep = JSON.stringify(targetObject);
+  stringRep = stringRep.replace(/(\d\d\d\d-\d\d-\d\d[Tt]\d\d:\d\d:\d\d)\.\d{3,7}([Zz]|[+-]00:00)/g, "$1Z");
+  return JSON.parse(stringRep);
+}
+
+Scenarios.Basic_put = passOnSuccess(
+  mockapi.put("/complex/basic/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      req.expect.bodyEquals({ id: 2, name: "abc", color: "Magenta" });
+      return { status: 200 };
+    } else {
+      throw new ValidationError('Must specify scenario either "valid" or "empty"', null, req.params.scenario);
+    }
+  }),
+);
+
+Scenarios.Basic_get = passOnSuccess(
+  mockapi.get("/complex/basic/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      return { status: 200, body: json(JSON.parse('{ "id": 2, "name": "abc", "color": "YELLOW" }')) };
+    } else if (req.params.scenario === "empty") {
+      return { status: 200, body: json(JSON.parse("{ }")) };
+    } else if (req.params.scenario === "notprovided") {
+      return { status: 200 };
+    } else if (req.params.scenario === "null") {
+      return { status: 200, body: json(JSON.parse('{ "id": null, "name": null }')) };
+    } else if (req.params.scenario === "invalid") {
+      return { status: 200, body: json(JSON.parse('{ "id": "a", "name": "abc" }')) };
+    } else {
+      throw new ValidationError(
+        "Request scenario must be valid, empty, null, notprovided, or invalid.",
+        null,
+        req.params.scenario,
+      );
+    }
+  }),
+);
+
+/**
+ * Put and get for inhertiance.
+ */
+const siamese =
+  '{"breed":"persian","color":"green","hates":[{"food":"tomato","id":1,"name":"Potato"},{"food":"french fries","id":-1,"name":"Tomato"}],"id":2,"name":"Siameeee"}';
+Scenarios.Inheritance_put = passOnSuccess(
+  mockapi.put("/complex/inheritance/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      req.expect.bodyEquals(JSON.parse(siamese));
+      return { status: 200 };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);
+
+Scenarios.Inheritance_get = passOnSuccess(
+  mockapi.get("/complex/inheritance/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      return { status: 200, body: json(JSON.parse(siamese)) };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);
+
+/**
+ * Put and get for polymorphism.
+ */
+const rawFish = {
+  fishtype: "salmon",
+  location: "alaska",
+  iswild: true,
+  species: "king",
+  length: 1.0,
+  siblings: [
+    {
+      fishtype: "shark",
+      age: 6,
+      birthday: "2012-01-05T01:00:00Z",
+      length: 20.0,
+      species: "predator",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "sawshark",
+      age: 105,
+      birthday: "1900-01-05T01:00:00Z",
+      length: 10.0,
+      picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+      species: "dangerous",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "goblin",
+      age: 1,
+      birthday: "2015-08-08T00:00:00Z",
+      length: 30.0,
+      species: "scary",
+      jawsize: 5,
+      // Intentionally requiring a value not defined in the enum, since
+      // such values should be allowed to be sent to/received from the server
+      color: "pinkish-gray",
+    },
+  ],
+};
+const rawSalmon = {
+  fishtype: "smart_salmon",
+  location: "alaska",
+  iswild: true,
+  species: "king",
+  additionalProperty1: 1,
+  additionalProperty2: false,
+  additionalProperty3: "hello",
+  additionalProperty4: { a: 1, b: 2 },
+  additionalProperty5: [1, 3],
+  length: 1.0,
+  siblings: [
+    {
+      fishtype: "shark",
+      age: 6,
+      birthday: "2012-01-05T01:00:00Z",
+      length: 20.0,
+      species: "predator",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "sawshark",
+      age: 105,
+      birthday: "1900-01-05T01:00:00Z",
+      length: 10.0,
+      picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+      species: "dangerous",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "goblin",
+      age: 1,
+      birthday: "2015-08-08T00:00:00Z",
+      length: 30.0,
+      species: "scary",
+      jawsize: 5,
+      color: "pinkish-gray",
+    },
+  ],
+};
+
+const regularSalmon = {
+  fishtype: "salmon",
+  location: "alaska",
+  iswild: true,
+  species: "king",
+  length: 1.0,
+  siblings: [
+    {
+      fishtype: "shark",
+      age: 6,
+      birthday: "2012-01-05T01:00:00Z",
+      length: 20.0,
+      species: "predator",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "sawshark",
+      age: 105,
+      birthday: "1900-01-05T01:00:00Z",
+      length: 10.0,
+      picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+      species: "dangerous",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "goblin",
+      age: 1,
+      birthday: "2015-08-08T00:00:00Z",
+      length: 30.0,
+      species: "scary",
+      jawsize: 5,
+      color: "pinkish-gray",
+    },
+  ],
+};
+
+const regularSalmonWithoutDiscriminator = {
+  location: "alaska",
+  iswild: true,
+  species: "king",
+  length: 1.0,
+  siblings: [
+    {
+      fishtype: "shark",
+      age: 6,
+      birthday: "2012-01-05T01:00:00Z",
+      length: 20.0,
+      species: "predator",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "sawshark",
+      age: 105,
+      birthday: "1900-01-05T01:00:00Z",
+      length: 10.0,
+      picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+      species: "dangerous",
+    },
+    {
+      fishtype: "shark",
+      sharktype: "goblin",
+      age: 1,
+      birthday: "2015-08-08T00:00:00Z",
+      length: 30.0,
+      species: "scary",
+      jawsize: 5,
+      color: "pinkish-gray",
+    },
+  ],
+};
+
+const dotSalmon = {
+  fish_type: "DotSalmon",
+  location: "sweden",
+  iswild: true,
+  species: "king",
+};
+
+const dotFishMarketWithDiscriminator = {
+  sampleSalmon: {
+    fish_type: "DotSalmon",
+    location: "sweden",
+    iswild: false,
+    species: "king",
+  },
+  salmons: [
+    {
+      fish_type: "DotSalmon",
+      location: "sweden",
+      iswild: false,
+      species: "king",
+    },
+    {
+      fish_type: "DotSalmon",
+      location: "atlantic",
+      iswild: true,
+      species: "king",
+    },
+  ],
+  sampleFish: {
+    fish_type: "DotSalmon",
+    location: "australia",
+    iswild: false,
+    species: "king",
+  },
+  fishes: [
+    {
+      fish_type: "DotSalmon",
+      location: "australia",
+      iswild: false,
+      species: "king",
+    },
+    {
+      fish_type: "DotSalmon",
+      location: "canada",
+      iswild: true,
+      species: "king",
+    },
+  ],
+};
+
+const dotFishMarketWithoutDiscriminator = {
+  sampleSalmon: {
+    location: "sweden",
+    iswild: false,
+    species: "king",
+  },
+  salmons: [
+    {
+      location: "sweden",
+      iswild: false,
+      species: "king",
+    },
+    {
+      location: "atlantic",
+      iswild: true,
+      species: "king",
+    },
+  ],
+  sampleFish: {
+    location: "australia",
+    iswild: false,
+    species: "king",
+  },
+  fishes: [
+    {
+      location: "australia",
+      iswild: false,
+      species: "king",
+    },
+    {
+      location: "canada",
+      iswild: true,
+      species: "king",
+    },
+  ],
+};
+
+Scenarios.Polymorphism_dotsyntax_get = passOnSuccess(
+  mockapi.get("/complex/polymorphism/dotsyntax", (req) => {
+    return { status: 200, body: json(dotSalmon) };
+  }),
+);
+
+Scenarios.Polymorphism_composedWithDiscriminator_get = passOnSuccess(
+  mockapi.get("/complex/polymorphism/composedWithDiscriminator", (req) => {
+    return { status: 200, body: json(dotFishMarketWithDiscriminator) };
+  }),
+);
+
+Scenarios.Polymorphism_composedWithoutDiscriminator_get = passOnSuccess(
+  mockapi.get("/complex/polymorphism/composedWithoutDiscriminator", (req) => {
+    return { status: 200, body: json(dotFishMarketWithoutDiscriminator) };
+  }),
+);
+
+Scenarios.Polymorphism_put = passOnSuccess(
+  mockapi.put("/complex/polymorphism/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      console.log(JSON.stringify(req.body, null, 4));
+      console.log(JSON.stringify(rawFish, null, 4));
+      req.expect.deepEqual(coerceDate(req.body), rawFish);
+      return { status: 200 };
+    } else if (req.params.scenario === "complicated") {
+      console.log(JSON.stringify(req.body, null, 4));
+      console.log(JSON.stringify(rawSalmon, null, 4));
+      req.expect.deepEqual(coerceDate(req.body), rawSalmon);
+      return { status: 200 };
+    } else if (req.params.scenario === "missingdiscriminator") {
+      console.log(JSON.stringify(req.body, null, 4));
+      console.log(JSON.stringify(regularSalmon, null, 4));
+      req.expect.deepEqual(coerceDate(req.body), regularSalmon);
+      return { status: 200, body: json(regularSalmonWithoutDiscriminator) };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);
+
+Scenarios.Polymorphism_get = passOnSuccess(
+  mockapi.get("/complex/polymorphism/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      return { status: 200, body: json(rawFish) };
+    } else if (req.params.scenario === "complicated") {
+      return { status: 200, body: json(rawSalmon) };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);
+
+Scenarios.Polymorphism_missingrequired_invalid_get = passOnSuccess(
+  mockapi.put("/complex/polymorphism/missingrequired/invalid", (req) => {
+    throw new ValidationError(
+      "Reached server in scenario: /complex/polymorphism/missingrequired/invalid, and should not have - since required fields are missing from the request, the client should not be able to send it.",
+      null,
+      null,
+    );
+  }),
+);
+
+/**
+ * Put and get for recursive reference.
+ */
+const bigfishRaw = {
+  fishtype: "salmon",
+  location: "alaska",
+  iswild: true,
+  species: "king",
+  length: 1,
+  siblings: [
+    {
+      fishtype: "shark",
+      age: 6,
+      birthday: "2012-01-05T01:00:00Z",
+      species: "predator",
+      length: 20,
+      siblings: [
+        {
+          fishtype: "salmon",
+          location: "atlantic",
+          iswild: true,
+          species: "coho",
+          length: 2,
+          siblings: [
+            {
+              fishtype: "shark",
+              age: 6,
+              birthday: "2012-01-05T01:00:00Z",
+              species: "predator",
+              length: 20,
+            },
+            {
+              fishtype: "shark",
+              sharktype: "sawshark",
+              age: 105,
+              birthday: "1900-01-05T01:00:00Z",
+              picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+              species: "dangerous",
+              length: 10,
+            },
+          ],
+        },
+        {
+          fishtype: "shark",
+          sharktype: "sawshark",
+          age: 105,
+          birthday: "1900-01-05T01:00:00Z",
+          picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+          species: "dangerous",
+          length: 10,
+          siblings: [],
+        },
+      ],
+    },
+    {
+      fishtype: "shark",
+      sharktype: "sawshark",
+      age: 105,
+      birthday: "1900-01-05T01:00:00Z",
+      picture: new Buffer([255, 255, 255, 255, 254]).toString("base64"),
+      species: "dangerous",
+      length: 10,
+      siblings: [],
+    },
+  ],
+};
+
+Scenarios.Polymorphicrecursive_put = passOnSuccess(
+  mockapi.put("/complex/polymorphicrecursive/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      console.log(JSON.stringify(req.body, null, 4));
+      console.log(JSON.stringify(bigfishRaw, null, 4));
+      req.expect.deepEqual(coerceDate(req.body), bigfishRaw);
+      return { status: 200 };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);
+
+Scenarios.Polymorphicrecursive_get = passOnSuccess(
+  mockapi.get("/complex/polymorphicrecursive/:scenario", (req) => {
+    if (req.params.scenario === "valid") {
+      return { status: 200, body: json(bigfishRaw) };
+    } else {
+      throw new ValidationError("Must provide a valid scenario.", null, req.params.scenario);
+    }
+  }),
+);


### PR DESCRIPTION
This PR is for migrating [body-complex](https://github.com/Azure/autorest.testserver/blob/main/swagger/body-complex.json) in autorest.testserver into cadl.
Since there are already projects for primitives, collections and readonly in cadl-ranch, I don't add related tests in body-complex to here.
I split the remains into two packages as `dictionary` and `inheritance-complex`:
- dictionary: for cadl datatype `Record`
- inheritance-complex: provide testcases for complex polymorphic scenario

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
