### PR TITLE
fix extensible enums mock api tests

### DIFF
--- a/packages/cadl-ranch-specs/http/extensible-enums/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/extensible-enums/mockapi.ts
@@ -11,7 +11,7 @@ Scenarios.ExtensibleEnums_String_getKnownValue = passOnSuccess(
 );
 
 Scenarios.ExtensibleEnums_String_putKnownValue = passOnSuccess(
-  mockapi.get("/extensible-enums/string/known-value", (req) => {
+  mockapi.put("/extensible-enums/string/known-value", (req) => {
     req.expect.bodyEquals("Monday");
     return { status: 204 };
   }),
@@ -19,13 +19,13 @@ Scenarios.ExtensibleEnums_String_putKnownValue = passOnSuccess(
 
 // Unknown values
 Scenarios.ExtensibleEnums_String_getUnknownValue = passOnSuccess(
-  mockapi.get("/extensible-enums/string/known-value", (req) => {
+  mockapi.get("/extensible-enums/string/unknown-value", (req) => {
     return { status: 200, body: json("Weekend") };
   }),
 );
 
 Scenarios.ExtensibleEnums_String_putUnknownValue = passOnSuccess(
-  mockapi.get("/extensible-enums/string/known-value", (req) => {
+  mockapi.put("/extensible-enums/string/unknown-value", (req) => {
     req.expect.bodyEquals("Weekend");
     return { status: 204 };
   }),

--- a/packages/cadl-ranch-specs/package.json
+++ b/packages/cadl-ranch-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch-specs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Cadl scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
