### PR TITLE
bug fix, update models/property-optional /duration operation

### DIFF
--- a/.changeset/friendly-timers-draw.md
+++ b/.changeset/friendly-timers-draw.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+bug fix, update models/property-optional /duration operation

--- a/packages/cadl-ranch-specs/http/models/property-optional/main.cadl
+++ b/packages/cadl-ranch-specs/http/models/property-optional/main.cadl
@@ -103,7 +103,7 @@ interface Datetime extends OperationsTemplate<DatetimeProperty, "2022-08-26T18:3
 
 // Model with optional duration property
 @doc("Model with a duration property")
-model DurationProperty is ModelTemplate<zonedDateTime>;
+model DurationProperty is ModelTemplate<duration>;
 @route("/duration")
 interface Duration extends OperationsTemplate<DurationProperty, "P123DT22H14M12.011S"> {}
 


### PR DESCRIPTION
Hi @timotheeguerin & @iscai-msft ,
Found a similar issue to this: https://github.com/Azure/cadl-ranch/issues/90, similar fixed pr https://github.com/Azure/cadl-ranch/pull/89. This

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
