### PR TITLE
fix lro: add response body for Azure_Lro_PollingSuccess

### DIFF
--- a/.changeset/smart-rules-nail.md
+++ b/.changeset/smart-rules-nail.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+fix lro mockapi: add response body for Azure_Lro_PollingSuccess

--- a/packages/cadl-ranch-specs/http/lro/lro-basic/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/lro/lro-basic/mockapi.ts
@@ -5,7 +5,11 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Azure_Lro_PollingSuccess = passOnSuccess([
   mockapi.put("/lro/basic/put", (req) => {
-    return { status: 200, headers: { "operation-location": "http://localhost:3000/lro/basic/put/polling" } };
+    return {
+      status: 200,
+      headers: { "operation-location": "http://localhost:3000/lro/basic/put/polling" },
+      body: json("On going..."),
+    };
   }),
   mockapi.get("/lro/basic/put/polling", (req) => {
     return { status: 200, body: json({ status: "Succeeded" }) };


### PR DESCRIPTION
Adding response body in mockapi since cadl defined string response:
https://github.com/Azure/cadl-ranch/blob/main/packages/cadl-ranch-specs/http/lro/lro-basic/main.cadl#L20


# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
