### PR TITLE
add testcases for special words as operation/parameter/property names

### DIFF
--- a/.changeset/thirty-tigers-tease.md
+++ b/.changeset/thirty-tigers-tease.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+- add testcases for using special words as operation/parameter/property names

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1410,3 +1410,49 @@ The value you pass for the parameter is not verified by the mock server.
 
 Show that you can call a GET HTTP endpoint.
 This is a totally new operation in this API version.
+
+### SpecialWords_Operation_for
+
+- Endpoint: `get /special-words/operation/for`
+
+A operation name of `for` should work.
+
+### SpecialWords_Parameter_getWithIf
+
+- Endpoint: `get /special-words/parameter/if`
+
+Expect input parameter `if='weekend'`
+
+### SpecialWords_Parameter_getWithFilter
+
+- Endpoint: `get /special-words/parameter/filter`
+
+Expect input parameter `filter='abc*.'`
+
+### SpecialWords_Model_get
+
+- Endpoint: `get /special-words/model/get`
+
+Expected response body:
+
+```json
+{
+  "model.kind": "derived",
+  "derived.name": "my.name",
+  "for": "value"
+}
+```
+
+### SpecialWords_Model_put
+
+- Endpoint: `put /special-words/model/put`
+
+Expected input body:
+
+```json
+{
+  "model.kind": "derived",
+  "derived.name": "my.name",
+  "for": "value"
+}
+```

--- a/packages/cadl-ranch-specs/http/special-words/main.cadl
+++ b/packages/cadl-ranch-specs/http/special-words/main.cadl
@@ -1,0 +1,85 @@
+import "@cadl-lang/rest";
+import "@azure-tools/cadl-ranch-expect";
+import "@azure-tools/cadl-dpg";
+
+using Cadl.Http;
+using Azure.DPG;
+
+@doc("Illustrates operation, parameter and property have name of special words or characters.")
+@scenarioService("/special-words")
+namespace SpecialWords;
+
+@route("/operation")
+@doc("This interface is for testing operations has a special name.")
+@operationGroup
+interface Operation {
+  @scenario
+  @scenarioDoc("A operation name of `for` should work.")
+  @get
+  @route("/for")
+  for(): void;
+}
+
+@route("/parameter")
+@doc("This interface is for testing operations parameters of special words.")
+@operationGroup
+interface Parameter {
+  @scenario
+  @scenarioDoc("Expect input parameter `if='weekend'`")
+  @get
+  @route("/if")
+  getWithIf(@header "if": string): void;
+
+  @scenario
+  @scenarioDoc("Expect input parameter `filter='abc*.'`")
+  @get
+  @route("/filter")
+  getWithFilter(@query filter: string): void;
+}
+
+@doc("This is a base model has discriminator name containing dot.")
+@discriminator("model.kind")
+model BaseModel {}
+
+@doc("This is a model has property names of special words or characters.")
+@discriminator("model.kind")
+model DerivedModel extends BaseModel {
+  "model.kind": "derived";
+  "derived.name": string;
+  for: string;
+}
+
+@route("/model")
+@doc("This interface is for testing models and properties of special words.")
+@operationGroup
+interface Model {
+  @scenario
+  @scenarioDoc("""
+  Expected response body:
+  ```json
+  {
+    "model.kind": "derived",
+    "derived.name": "my.name",
+    "for": "value",
+  }
+  ```
+  """)
+  @route("/get")
+  @get
+  get(): BaseModel;
+
+  @scenario
+  @scenarioDoc("""
+  Expected input body:
+  ```json
+    {
+    "model.kind": "derived",
+    "derived.name": "my.name",
+    "for": "value",
+  }
+  ```
+  """)
+  @route("/put")
+  @put
+  put(@body body: BaseModel): void;
+}

--- a/packages/cadl-ranch-specs/http/special-words/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/special-words/mockapi.ts
@@ -10,7 +10,7 @@ Scenarios.SpecialWords_Operation_for = passOnSuccess(
   }),
 );
 
-Scenarios.SpecialWords_Parameter_if = passOnSuccess(
+Scenarios.SpecialWords_Parameter_getWithIf = passOnSuccess(
   mockapi.get("/special-words/parameter/if", (req) => {
     req.expect.containsHeader("if", "weekend");
     return {
@@ -18,7 +18,7 @@ Scenarios.SpecialWords_Parameter_if = passOnSuccess(
     };
   }),
 );
-Scenarios.SpecialWords_Parameter_filter = passOnSuccess(
+Scenarios.SpecialWords_Parameter_getWithFilter = passOnSuccess(
   mockapi.get("/special-words/parameter/filter", (req) => {
     req.expect.containsQueryParam("filter", "abc*.");
     return {

--- a/packages/cadl-ranch-specs/http/special-words/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/special-words/mockapi.ts
@@ -1,0 +1,61 @@
+import { passOnSuccess, ScenarioMockApi, mockapi, json } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.SpecialWords_Operation_for = passOnSuccess(
+  mockapi.get("/special-words/operation/for", (req) => {
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.SpecialWords_Parameter_if = passOnSuccess(
+  mockapi.get("/special-words/parameter/if", (req) => {
+    req.expect.containsHeader("if", "weekend");
+    return {
+      status: 204,
+    };
+  }),
+);
+Scenarios.SpecialWords_Parameter_filter = passOnSuccess(
+  mockapi.get("/special-words/parameter/filter", (req) => {
+    req.expect.containsQueryParam("filter", "abc*.");
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.SpecialWords_Model_getContinue = passOnSuccess(
+  mockapi.get("/special-words/model/getContinue", (req) => {
+    return {
+      status: 200,
+      body: json({
+        name: "abc",
+      }),
+    };
+  }),
+);
+
+const modelValue = {
+  "model.kind": "derived",
+  "derived.name": "my.name",
+  "for": "value",
+};
+Scenarios.SpecialWords_Model_get = passOnSuccess(
+  mockapi.get("/special-words/model/get", (req) => {
+    return {
+      status: 200,
+      body: json(modelValue),
+    };
+  }),
+);
+Scenarios.SpecialWords_Model_put = passOnSuccess(
+  mockapi.put("/special-words/model/put", (req) => {
+    req.expect.bodyEquals(modelValue);
+    return {
+      status: 204,
+    };
+  }),
+);


### PR DESCRIPTION

Add testcases for https://github.com/Azure/autorest.python/issues/1380

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
