### PR TITLE
fix mockapi of getting datetime

### DIFF
--- a/packages/cadl-ranch-specs/http/models/property-optional/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/models/property-optional/mockapi.ts
@@ -20,6 +20,9 @@ function createMockApis(route: string, value: any, convertBodyProperty?: (_: any
   const defaultUrl = `${url}/default`;
   const allBody = { property: value };
   const defaultBody = {};
+  if (convertBodyProperty && allBody.property) {
+    allBody.property = convertBodyProperty(allBody.property);
+  }
   const getAll = mockapi.get(allUrl, (req) => {
     return {
       status: 200,
@@ -33,9 +36,8 @@ function createMockApis(route: string, value: any, convertBodyProperty?: (_: any
     };
   });
   const putAll = mockapi.put(allUrl, (req) => {
-    if (convertBodyProperty && req.originalRequest.body?.property && allBody?.property) {
+    if (convertBodyProperty && req.originalRequest.body?.propertyy) {
       req.originalRequest.body.property = convertBodyProperty(req.originalRequest.body.property);
-      allBody.property = convertBodyProperty(allBody.property);
     }
 
     req.expect.bodyEquals(allBody);

--- a/packages/cadl-ranch-specs/http/models/property-types/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/models/property-types/mockapi.ts
@@ -15,6 +15,9 @@ interface MockApiGetPut {
 function createMockApis(route: string, value: any, convertBodyProperty?: (_: any) => any): MockApiGetPut {
   const url = `/models/properties/types/${route}`;
   const body = { property: value };
+  if (convertBodyProperty && body.property) {
+    body.property = convertBodyProperty(body.property);
+  }
   return {
     get: mockapi.get(url, (req) => {
       return {
@@ -23,9 +26,8 @@ function createMockApis(route: string, value: any, convertBodyProperty?: (_: any
       };
     }),
     put: mockapi.put(url, (req) => {
-      if (convertBodyProperty && req.originalRequest.body?.property && body?.property) {
+      if (convertBodyProperty && req.originalRequest.body?.property) {
         req.originalRequest.body.property = convertBodyProperty(req.originalRequest.body.property);
-        body.property = convertBodyProperty(body.property);
       }
 
       req.expect.bodyEquals(body);


### PR DESCRIPTION
### For fixing below problem:
Currently, the result of `get` operation on datetime in packages `property-optional` and `property-types` varies depending on the sequence of the executing of testcases:
+ If the `put datetime` is executed before `get datetime`, then the result of the `get` is "2022-08-26T18:38:00.000Z";
+ If the `get datetime` invoked ahead of `put datetime`, then the result of the `get` is "2022-08-26T18:38:00Z".

### Fix
This PR make the result of the `get` solid to be "2022-08-26T18:38:00.000Z".










# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
