### PR TITLE
models/usage, fix but that senario url and mockapi url mismatch

### DIFF
--- a/.changeset/fluffy-monkeys-serve.md
+++ b/.changeset/fluffy-monkeys-serve.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+models/usage, fix but that senario url and mockapi url mismatch

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1256,19 +1256,19 @@ Generate, send, and receive round-trip model with readonly properties.
 
 ### Models_Usage_input
 
-- Endpoint: `get /models/usages/input`
+- Endpoint: `get /models/usage/input`
 
 Send a POST request with the following body {requiredProp: "example-value"}
 
 ### Models_Usage_output
 
-- Endpoint: `get /models/usages/output`
+- Endpoint: `get /models/usage/output`
 
 Send a GET request which return the following body {requiredProp: "example-value"}
 
 ### Models_Usage_inputAndOutput
 
-- Endpoint: `get /models/usages/input-output`
+- Endpoint: `get /models/usage/input-output`
 
 Send a POST request which return the following body {requiredProp: "example-value"} and return the same.
 

--- a/packages/cadl-ranch-specs/http/models/usage/main.cadl
+++ b/packages/cadl-ranch-specs/http/models/usage/main.cadl
@@ -10,7 +10,7 @@ using Cadl.Http;
  * This is valuable if you for example only decide to create a public constructor if a model is used as input.
  */
 @doc("Illustrates usage of Record in different places(Operation parameters, return type or both).")
-@scenarioService("/models/usages")
+@scenarioService("/models/usage")
 namespace Models.Usage;
 
 alias RecordBase = {


### PR DESCRIPTION
The url in cadl definition and mockapi mismatch, so in generated sdk, it's `/models/usages/output`, but in mockapi, it's `/models/usage/output` (a missing `s`). This will lead to 404 when calling it in generated sdk.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
