### PR TITLE
Remove put operation in arrays

### DIFF
--- a/packages/cadl-ranch-specs/http/arrays/item-types/main.cadl
+++ b/packages/cadl-ranch-specs/http/arrays/item-types/main.cadl
@@ -26,22 +26,6 @@ interface ArrayOperations<TArr, TDoc extends string> {
   @get
   @convenienceAPI
   get(): TArr;
-
-  @scenario
-  @scenarioDoc(
-    """
-  Expected Array input body:
-  ```json
-  {doc}
-  ```
-  """,
-    {
-      doc: TDoc,
-    }
-  )
-  @put
-  @convenienceAPI
-  put(@body body: TArr): void;
 }
 
 @doc("Array of int32 values")


### PR DESCRIPTION
Array as put body is invalid, we will add such linter https://github.com/Azure/cadl-azure/issues/2194. So remove it from cadl-ranch.