### PR TITLE
Expose additionalMockApiPath parameter to inject user-defined mock apis.

### DIFF
--- a/packages/cadl-ranch/src/actions/serve.ts
+++ b/packages/cadl-ranch/src/actions/serve.ts
@@ -9,6 +9,7 @@ export interface ServeConfig {
   scenariosPath: string;
   coverageFile: string;
   port: number;
+  additionalMockApiPath: string | undefined;
 }
 
 export interface StopConfig {
@@ -22,6 +23,7 @@ export async function serve(config: ServeConfig) {
     port: config.port,
     scenarioPath: config.scenariosPath,
     coverageFile: config.coverageFile,
+    additionalMockApiPath: config.additionalMockApiPath
   });
   await server.start();
 }
@@ -40,6 +42,8 @@ export async function startInBackground(config: ServeConfig) {
         config.port.toString(),
         "--coverageFile",
         config.coverageFile,
+        "--additionalMockApiPath",
+        config.additionalMockApiPath,
       ],
       {
         detached: true,

--- a/packages/cadl-ranch/src/app/config.ts
+++ b/packages/cadl-ranch/src/app/config.ts
@@ -13,4 +13,6 @@ export interface ApiMockAppConfig {
    * Coverage file Path.
    */
   coverageFile: string;
+
+  additionalMockApiPath: string | undefined;
 }

--- a/packages/cadl-ranch/src/app/request-processor.ts
+++ b/packages/cadl-ranch/src/app/request-processor.ts
@@ -27,6 +27,20 @@ export async function processRequest(
   processResponse(response, mockResponse);
 }
 
+export async function processRequestWithoutCoverage(
+  request: RequestExt,
+  response: Response,
+  func: MockRequestHandler,
+): Promise<void> {
+  const mockRequest = new MockRequest(request);
+  const mockResponse = await callHandler(mockRequest, response, func);
+  if (mockResponse === undefined) {
+    return;
+  }
+
+  processResponse(response, mockResponse);
+}
+
 const processResponse = (response: Response, mockResponse: MockResponse) => {
   response.status(mockResponse.status);
 

--- a/packages/cadl-ranch/src/cli/cli.ts
+++ b/packages/cadl-ranch/src/cli/cli.ts
@@ -93,6 +93,11 @@ async function main() {
                 type: "string",
                 description: "Path to the coverage file.",
                 default: join(process.cwd(), "cadl-ranch-coverage.json"),
+              })
+              .option("additionalMockApiPath", {
+                type: "string",
+                description: "Additional path to mock apis",
+                default: undefined,
               });
           },
           async (args) =>
@@ -100,6 +105,7 @@ async function main() {
               scenariosPath: resolve(process.cwd(), args.scenariosPath),
               port: args.port,
               coverageFile: args.coverageFile,
+              additionalMockApiPath: args.additionalMockApiPath,
             }),
         )
         .command(
@@ -136,6 +142,11 @@ async function main() {
             type: "string",
             description: "Path to the coverage file.",
             default: join(process.cwd(), "cadl-ranch-coverage.json"),
+          })
+          .option("additionalMockApiPath", {
+            type: "string",
+            description: "Additional path to mock apis",
+            default: undefined,
           });
       },
       async (args) => {
@@ -143,6 +154,7 @@ async function main() {
           scenariosPath: resolve(process.cwd(), args.scenariosPath),
           port: args.port,
           coverageFile: args.coverageFile,
+          additionalMockApiPath: args.additionalMockApiPath,
         });
       },
     )


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
