### PR TITLE
Fix HEAD/GET ordering

### DIFF
--- a/.changeset/neat-zebras-perform.md
+++ b/.changeset/neat-zebras-perform.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+Fix HEAD/GET ordering in Models Visibility

--- a/packages/cadl-ranch-specs/http/models/visibility/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/models/visibility/mockapi.ts
@@ -20,6 +20,13 @@ function genData(keys: string[]): Record<string, any> {
   return ret;
 }
 
+Scenarios.Models_Visibility_Automatic_headModel = passOnSuccess(
+  mockapi.head("/models/visibility", (req) => {
+    req.expect.bodyEquals(genData(["queryProp"]));
+    return { status: 200 };
+  }),
+);
+
 Scenarios.Models_Visibility_Automatic_getModel = passOnSuccess(
   mockapi.get("/models/visibility", (req) => {
     req.expect.bodyEquals(genData(["queryProp"]));
@@ -27,13 +34,6 @@ Scenarios.Models_Visibility_Automatic_getModel = passOnSuccess(
       status: 200,
       body: json(genData(["readProp"])),
     };
-  }),
-);
-
-Scenarios.Models_Visibility_Automatic_headModel = passOnSuccess(
-  mockapi.head("/models/visibility", (req) => {
-    req.expect.bodyEquals(genData(["queryProp"]));
-    return { status: 200 };
   }),
 );
 


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
