### PR TITLE
fix @convenientAPI usage

### DIFF
--- a/.changeset/smooth-ducks-hang.md
+++ b/.changeset/smooth-ducks-hang.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+- fix @convenientAPI in arrays/item-types/main.cadl

--- a/packages/cadl-ranch-specs/http/arrays/item-types/main.cadl
+++ b/packages/cadl-ranch-specs/http/arrays/item-types/main.cadl
@@ -24,7 +24,7 @@ interface ArrayOperations<TArr, TDoc extends string> {
     }
   )
   @get
-  @convenientAPI
+  @convenientAPI(true)
   get(): TArr;
 
   @scenario
@@ -40,7 +40,7 @@ interface ArrayOperations<TArr, TDoc extends string> {
     }
   )
   @put
-  @convenientAPI
+  @convenientAPI(true)
   put(@body body: TArr): void;
 }
 


### PR DESCRIPTION
Fix below compile error when upgrading `@azure-tools/cadl-dpg` from "0.25.0" to "0.26.0-dev.5" in emitter:
![image](https://user-images.githubusercontent.com/59815250/215410328-67a6f33b-27ed-483c-af57-690b5c38f272.png)



# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
