### PR TITLE
Update azure core case for ResourceOperations

### DIFF
--- a/.changeset/dirty-guests-film.md
+++ b/.changeset/dirty-guests-film.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+Use ResourceOperations for Azure.Core Preview2

--- a/packages/cadl-ranch-specs/http/azure/core/main.cadl
+++ b/packages/cadl-ranch-specs/http/azure/core/main.cadl
@@ -3,12 +3,16 @@ import "@azure-tools/cadl-ranch-expect";
 import "@cadl-lang/rest";
 
 using Azure.Core;
+using global.Azure.Core.Traits;
 using Cadl.Rest;
 
 #suppress "@azure-tools/cadl-azure-core/casing-style" "For spec"
 @doc("Illustrates bodies templated with Azure Core")
 @scenarioService("/azure/core")
 namespace _Specs_.Azure.Core;
+
+interface ResourceOperations
+  extends global.Azure.Core.ResourceOperations<NoConditionalRequests & NoRepeatableRequests & NoClientRequestId> {}
 
 @resource("users")
 @doc("Details about a user.")
@@ -44,4 +48,4 @@ Expected response body:
 }
 ```
 """)
-op createOrUpdate is global.Azure.Core.ResourceCreateOrUpdate<User>;
+op createOrUpdate is ResourceOperations.ResourceCreateOrUpdate<User>;

--- a/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
@@ -4,7 +4,7 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
-  mockapi.patch("/azure/core/:id", (req) => {
+  mockapi.patch("/azure/core/users/:id", (req) => {
     if (req.params.id !== "1") {
       return { status: 400 };
     }


### PR DESCRIPTION
Fix a bug of route URL. Path should be `/azure/core/users/{id}` 

Migrate to `ResourceOperations` (service trait), as `Azure.Core.ResourceCreateOrUpdate` is [`@removed`](https://github.com/Azure/cadl-azure/blob/main/packages/cadl-azure-core/lib/operations.cadl#L324-L328)

It does not directly use `StandardResourceOperations`, as David told me `StandardResourceOperations` might get removed as well (prefer service to explicitly define the `ResourceOperations`).
relate to https://github.com/Azure/cadl-azure/issues/2468

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
