### PR TITLE
specs, azure/core, versioning and verify api-version

### DIFF
--- a/.changeset/strong-parents-crash.md
+++ b/.changeset/strong-parents-crash.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+Support versioning to azure/core test, validate the api-version in mockapi

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -240,6 +240,7 @@ Expects header 'authorization': 'Bearer https://security.microsoft.com/.default'
 Should only generate one model named User.
 
 Expected path parameter: id=1
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected input body:
 
@@ -265,6 +266,7 @@ Expected response body:
 Should only generate one model named User.
 
 Expected path parameter: id=1
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected input body:
 
@@ -290,6 +292,7 @@ Expected response body:
 Should only generate one model named User.
 
 Expected path parameter: id=1
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected response body:
 
@@ -307,6 +310,8 @@ Expected response body:
 Should only generate one model named User.
 
 Should not generate visible model like CustomPage.
+
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected response body:
 
@@ -331,6 +336,8 @@ Expected response body:
 
 Expected path parameter: id=1
 
+Expected query parameter: api-version=2022-12-01-preview
+
 Expected response of status code 204 with empty body.
 
 ### Azure_Core_export
@@ -341,6 +348,7 @@ Should only generate one model named User.
 
 Expected path parameter: id=1
 Expected query parameter: format=json
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected response body:
 

--- a/packages/cadl-ranch-specs/http/azure/core/main.cadl
+++ b/packages/cadl-ranch-specs/http/azure/core/main.cadl
@@ -1,16 +1,24 @@
 import "@azure-tools/cadl-azure-core";
 import "@azure-tools/cadl-ranch-expect";
 import "@cadl-lang/rest";
+import "@cadl-lang/versioning";
 
 using Azure.Core;
 using global.Azure.Core.Traits;
 using Cadl.Rest;
 using Cadl.Http;
+using Cadl.Versioning;
 
 #suppress "@azure-tools/cadl-azure-core/casing-style" "For spec"
 @doc("Illustrates bodies templated with Azure Core")
 @scenarioService("/azure/core")
+@versioned(_Specs_.Azure.Core.Versions)
 namespace _Specs_.Azure.Core;
+
+enum Versions {
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
 
 interface ResourceOperations
   extends global.Azure.Core.ResourceOperations<NoConditionalRequests & NoRepeatableRequests & NoClientRequestId> {}
@@ -41,6 +49,7 @@ model UserExportParams {
 Should only generate one model named User.
 
 Expected path parameter: id=1
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected input body:
 ```json
@@ -66,6 +75,7 @@ op createOrUpdate is ResourceOperations.ResourceCreateOrUpdate<User>;
 Should only generate one model named User.
 
 Expected path parameter: id=1
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected input body:
 ```json
@@ -91,6 +101,7 @@ op createOrReplace is ResourceOperations.ResourceCreateOrReplace<User>;
 Should only generate one model named User.
 
 Expected path parameter: id=1
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected response body:
 ```json
@@ -109,6 +120,8 @@ op get is ResourceOperations.ResourceRead<User>;
 Should only generate one model named User.
 
 Should not generate visible model like CustomPage.
+
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected response body:
 ```json
@@ -134,6 +147,8 @@ op list is ResourceOperations.ResourceList<User>;
 @scenarioDoc("""
 Expected path parameter: id=1
 
+Expected query parameter: api-version=2022-12-01-preview
+
 Expected response of status code 204 with empty body.
 """)
 op delete is ResourceOperations.ResourceDelete<User>;
@@ -146,6 +161,7 @@ Should only generate one model named User.
 
 Expected path parameter: id=1
 Expected query parameter: format=json
+Expected query parameter: api-version=2022-12-01-preview
 
 Expected response body:
 ```json

--- a/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
@@ -5,14 +5,12 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
   mockapi.patch("/azure/core/users/:id", (req) => {
-    if (req.query["api-version"] !== "2022-12-01-preview") {
-      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
-    }
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expect id=1" }) };
+      return { status: 400, body: json({ error: "Expected path param id=1" }) };
     }
-    const validBody = { name: "Madge" };
     req.expect.containsHeader("content-type", "application/merge-patch+json");
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    const validBody = { name: "Madge" };
     req.expect.bodyEquals(validBody);
     const responseBody = { id: 1, name: "Madge" };
     return { status: 200, body: json(responseBody) };
@@ -21,14 +19,12 @@ Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
 
 Scenarios.Azure_Core_createOrReplace = passOnSuccess(
   mockapi.put("/azure/core/users/:id", (req) => {
-    if (req.query["api-version"] !== "2022-12-01-preview") {
-      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
-    }
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expect id=1" }) };
+      return { status: 400, body: json({ error: "Expected path param id=1" }) };
     }
-    const validBody = { name: "Madge" };
     req.expect.containsHeader("content-type", "application/json");
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    const validBody = { name: "Madge" };
     req.expect.bodyEquals(validBody);
     const responseBody = { id: 1, name: "Madge" };
     return { status: 200, body: json(responseBody) };
@@ -37,12 +33,10 @@ Scenarios.Azure_Core_createOrReplace = passOnSuccess(
 
 Scenarios.Azure_Core_get = passOnSuccess(
   mockapi.get("/azure/core/users/:id", (req) => {
-    if (req.query["api-version"] !== "2022-12-01-preview") {
-      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
-    }
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expect id=1" }) };
+      return { status: 400, body: json({ error: "Expected path param id=1" }) };
     }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     const responseBody = { id: 1, name: "Madge" };
     return { status: 200, body: json(responseBody) };
   }),
@@ -50,9 +44,7 @@ Scenarios.Azure_Core_get = passOnSuccess(
 
 Scenarios.Azure_Core_list = passOnSuccess(
   mockapi.get("/azure/core/users", (req) => {
-    if (req.query["api-version"] !== "2022-12-01-preview") {
-      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
-    }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     const responseBody = {
       value: [
         { id: 1, name: "Madge" },
@@ -65,24 +57,18 @@ Scenarios.Azure_Core_list = passOnSuccess(
 
 Scenarios.Azure_Core_delete = passOnSuccess(
   mockapi.delete("/azure/core/users/:id", (req) => {
-    if (req.query["api-version"] !== "2022-12-01-preview") {
-      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
-    }
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expect id=1" }) };
+      return { status: 400, body: json({ error: "Expected path param id=1" }) };
     }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     return { status: 204 };
   }),
 );
 
 Scenarios.Azure_Core_export = passOnSuccess(
   mockapi.post("/azure/core/users/:id:export", (req) => {
-    if (req.query["api-version"] !== "2022-12-01-preview") {
-      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
-    }
-    if (req.query.format !== "json") {
-      return { status: 400, body: json({ error: "Expect format=json" }) };
-    }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    req.expect.containsQueryParam("format", "json");
     const responseBody = { id: 1, name: "Madge" };
     return { status: 200, body: json(responseBody) };
   }),

--- a/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, mockapi, json } from "@azure-tools/cadl-ranch-api";
+import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
@@ -6,7 +6,7 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
   mockapi.patch("/azure/core/users/:id", (req) => {
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expected path param id=1" }) };
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }
     req.expect.containsHeader("content-type", "application/merge-patch+json");
     req.expect.containsQueryParam("api-version", "2022-12-01-preview");
@@ -20,7 +20,7 @@ Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
 Scenarios.Azure_Core_createOrReplace = passOnSuccess(
   mockapi.put("/azure/core/users/:id", (req) => {
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expected path param id=1" }) };
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }
     req.expect.containsHeader("content-type", "application/json");
     req.expect.containsQueryParam("api-version", "2022-12-01-preview");
@@ -34,7 +34,7 @@ Scenarios.Azure_Core_createOrReplace = passOnSuccess(
 Scenarios.Azure_Core_get = passOnSuccess(
   mockapi.get("/azure/core/users/:id", (req) => {
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expected path param id=1" }) };
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }
     req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     const responseBody = { id: 1, name: "Madge" };
@@ -58,7 +58,7 @@ Scenarios.Azure_Core_list = passOnSuccess(
 Scenarios.Azure_Core_delete = passOnSuccess(
   mockapi.delete("/azure/core/users/:id", (req) => {
     if (req.params.id !== "1") {
-      return { status: 400, body: json({ error: "Expected path param id=1" }) };
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }
     req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     return { status: 204 };
@@ -67,6 +67,9 @@ Scenarios.Azure_Core_delete = passOnSuccess(
 
 Scenarios.Azure_Core_export = passOnSuccess(
   mockapi.post("/azure/core/users/:id:export", (req) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
     req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     req.expect.containsQueryParam("format", "json");
     const responseBody = { id: 1, name: "Madge" };

--- a/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/mockapi.ts
@@ -5,8 +5,11 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
   mockapi.patch("/azure/core/users/:id", (req) => {
+    if (req.query["api-version"] !== "2022-12-01-preview") {
+      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
+    }
     if (req.params.id !== "1") {
-      return { status: 400 };
+      return { status: 400, body: json({ error: "Expect id=1" }) };
     }
     const validBody = { name: "Madge" };
     req.expect.containsHeader("content-type", "application/merge-patch+json");
@@ -18,8 +21,11 @@ Scenarios.Azure_Core_createOrUpdate = passOnSuccess(
 
 Scenarios.Azure_Core_createOrReplace = passOnSuccess(
   mockapi.put("/azure/core/users/:id", (req) => {
+    if (req.query["api-version"] !== "2022-12-01-preview") {
+      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
+    }
     if (req.params.id !== "1") {
-      return { status: 400 };
+      return { status: 400, body: json({ error: "Expect id=1" }) };
     }
     const validBody = { name: "Madge" };
     req.expect.containsHeader("content-type", "application/json");
@@ -31,8 +37,11 @@ Scenarios.Azure_Core_createOrReplace = passOnSuccess(
 
 Scenarios.Azure_Core_get = passOnSuccess(
   mockapi.get("/azure/core/users/:id", (req) => {
+    if (req.query["api-version"] !== "2022-12-01-preview") {
+      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
+    }
     if (req.params.id !== "1") {
-      return { status: 400 };
+      return { status: 400, body: json({ error: "Expect id=1" }) };
     }
     const responseBody = { id: 1, name: "Madge" };
     return { status: 200, body: json(responseBody) };
@@ -41,6 +50,9 @@ Scenarios.Azure_Core_get = passOnSuccess(
 
 Scenarios.Azure_Core_list = passOnSuccess(
   mockapi.get("/azure/core/users", (req) => {
+    if (req.query["api-version"] !== "2022-12-01-preview") {
+      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
+    }
     const responseBody = {
       value: [
         { id: 1, name: "Madge" },
@@ -53,8 +65,11 @@ Scenarios.Azure_Core_list = passOnSuccess(
 
 Scenarios.Azure_Core_delete = passOnSuccess(
   mockapi.delete("/azure/core/users/:id", (req) => {
+    if (req.query["api-version"] !== "2022-12-01-preview") {
+      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
+    }
     if (req.params.id !== "1") {
-      return { status: 400 };
+      return { status: 400, body: json({ error: "Expect id=1" }) };
     }
     return { status: 204 };
   }),
@@ -62,8 +77,11 @@ Scenarios.Azure_Core_delete = passOnSuccess(
 
 Scenarios.Azure_Core_export = passOnSuccess(
   mockapi.post("/azure/core/users/:id:export", (req) => {
+    if (req.query["api-version"] !== "2022-12-01-preview") {
+      return { status: 400, body: json({ error: "Expect api-version=2022-12-01-preview" }) };
+    }
     if (req.query.format !== "json") {
-      return { status: 400 };
+      return { status: 400, body: json({ error: "Expect format=json" }) };
     }
     const responseBody = { id: 1, name: "Madge" };
     return { status: 200, body: json(responseBody) };


### PR DESCRIPTION
Context: some emitter would like to have `@versioned` supporting versioning, as Azure.Core operations does include "api-version" in query parameter automatically.

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
