### PR TITLE
update collection format test

### DIFF
--- a/.changeset/chatty-timers-chew.md
+++ b/.changeset/chatty-timers-chew.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+update mock response for collection format test case

--- a/packages/cadl-ranch-specs/http/collectionFormat/main.cadl
+++ b/packages/cadl-ranch-specs/http/collectionFormat/main.cadl
@@ -35,7 +35,7 @@ alias DefaultCollectionFormatParameter = {
   colors: string[];
 };
 
-model Message {
+model MessageResponse {
   message: string;
 }
 
@@ -44,14 +44,14 @@ model Message {
 This test is testing sending a multi collection format array query parameters
 """)
 @route("/multi")
-op testMulti(...MultiCollectionFormatParameter): Message;
+op testMulti(...MultiCollectionFormatParameter): MessageResponse;
 
 @scenario
 @scenarioDoc("""
 This test is testing sending a csv collection format array query parameters
 """)
 @route("/csv")
-op testCsv(...CsvCollectionFormatParameter): Message;
+op testCsv(...CsvCollectionFormatParameter): MessageResponse;
 
 // @scenario
 // @scenarioDoc("""

--- a/packages/cadl-ranch-specs/http/collectionFormat/main.cadl
+++ b/packages/cadl-ranch-specs/http/collectionFormat/main.cadl
@@ -35,19 +35,23 @@ alias DefaultCollectionFormatParameter = {
   colors: string[];
 };
 
+model Message {
+  message: string;
+}
+
 @scenario
 @scenarioDoc("""
 This test is testing sending a multi collection format array query parameters
 """)
 @route("/multi")
-op testMulti(...MultiCollectionFormatParameter): string;
+op testMulti(...MultiCollectionFormatParameter): Message;
 
 @scenario
 @scenarioDoc("""
 This test is testing sending a csv collection format array query parameters
 """)
 @route("/csv")
-op testCsv(...CsvCollectionFormatParameter): string;
+op testCsv(...CsvCollectionFormatParameter): Message;
 
 // @scenario
 // @scenarioDoc("""

--- a/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
@@ -24,7 +24,7 @@ Scenarios.CollectionFormat_testCsv = passOnSuccess(
     req.expect.containsQueryParam("colors", "blue,red,green");
     return {
       status: 200,
-      body: json( `A multi collection format array was successfully received`),
+      body: json(`A multi collection format array was successfully received`),
     };
   }),
 );

--- a/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
@@ -8,12 +8,12 @@ Scenarios.CollectionFormat_testMulti = passOnSuccess(
     if (req.originalRequest.originalUrl.includes("colors=blue&colors=red&colors=green")) {
       return {
         status: 200,
-        body: json({ message: `A multi collection format array was successfully received`}),
+        body: json({ message: `A multi collection format array was successfully received` }),
       };
     } else {
       return {
         status: 400,
-        body: json({ message: `Expected colors=blue&colors=red&colors=green after serialization`}),
+        body: json({ message: `Expected colors=blue&colors=red&colors=green after serialization` }),
       };
     }
   }),
@@ -27,12 +27,12 @@ Scenarios.CollectionFormat_testCsv = passOnSuccess(
     ) {
       return {
         status: 200,
-        body: json({ message: `A multi collection format array was successfully received`}),
+        body: json({ message: `A multi collection format array was successfully received` }),
       };
     } else {
       return {
         status: 400,
-        body: json({ message: `Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization`}),
+        body: json({ message: `Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization` }),
       };
     }
   }),

--- a/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
+import { passOnSuccess, mockapi, json } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
@@ -27,12 +27,12 @@ Scenarios.CollectionFormat_testCsv = passOnSuccess(
     ) {
       return {
         status: 200,
-        body: json({ message: `A multi collection format array was successfully received` }),
+        body: json(`A multi collection format array was successfully received`),
       };
     } else {
       return {
         status: 400,
-        body: json({ message: `Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization` }),
+        body: json(`Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization`),
       };
     }
   }),

--- a/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
@@ -8,12 +8,12 @@ Scenarios.CollectionFormat_testMulti = passOnSuccess(
     if (req.originalRequest.originalUrl.includes("colors=blue&colors=red&colors=green")) {
       return {
         status: 200,
-        body: json(`A multi collection format array was successfully received`),
+        body: json({ message: `A multi collection format array was successfully received`}),
       };
     } else {
       return {
         status: 400,
-        body: json(`Expected colors=blue&colors=red&colors=green after serialization`),
+        body: json({ message: `Expected colors=blue&colors=red&colors=green after serialization`}),
       };
     }
   }),
@@ -27,12 +27,12 @@ Scenarios.CollectionFormat_testCsv = passOnSuccess(
     ) {
       return {
         status: 200,
-        body: json(`A multi collection format array was successfully received`),
+        body: json({ message: `A multi collection format array was successfully received`}),
       };
     } else {
       return {
         status: 400,
-        body: json(`Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization`),
+        body: json({ message: `Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization`}),
       };
     }
   }),

--- a/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, mockapi, json } from "@azure-tools/cadl-ranch-api";
+import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
@@ -21,11 +21,20 @@ Scenarios.CollectionFormat_testMulti = passOnSuccess(
 
 Scenarios.CollectionFormat_testCsv = passOnSuccess(
   mockapi.get("/collectionFormat/csv", (req) => {
-    req.expect.containsQueryParam("colors", "blue,red,green");
-    return {
-      status: 200,
-      body: json(`A multi collection format array was successfully received`),
-    };
+    if (
+      req.originalRequest.originalUrl.includes("colors=blue,red,green") ||
+      req.originalRequest.originalUrl.includes("colors=blue%2Cred%2Cgreen")
+    ) {
+      return {
+        status: 200,
+        body: json({ message: `A multi collection format array was successfully received` }),
+      };
+    } else {
+      return {
+        status: 400,
+        body: json({ message: `Expected colors=blue,red,green or colors=blue%2Cred%2Cgreen after serialization` }),
+      };
+    }
   }),
 );
 

--- a/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/collectionFormat/mockapi.ts
@@ -8,12 +8,12 @@ Scenarios.CollectionFormat_testMulti = passOnSuccess(
     if (req.originalRequest.originalUrl.includes("colors=blue&colors=red&colors=green")) {
       return {
         status: 200,
-        body: json({ message: `A multi collection format array was successfully received` }),
+        body: json(`A multi collection format array was successfully received`),
       };
     } else {
       return {
         status: 400,
-        body: json({ message: `Expected colors=blue&colors=red&colors=green after serialization` }),
+        body: json(`Expected colors=blue&colors=red&colors=green after serialization`),
       };
     }
   }),
@@ -24,7 +24,7 @@ Scenarios.CollectionFormat_testCsv = passOnSuccess(
     req.expect.containsQueryParam("colors", "blue,red,green");
     return {
       status: 200,
-      body: json({ message: `A multi collection format array was successfully received` }),
+      body: json( `A multi collection format array was successfully received`),
     };
   }),
 );


### PR DESCRIPTION
1. update response body from object to string

[Cadl definition](https://github.com/Azure/cadl-ranch/blob/main/packages/cadl-ranch-specs/http/collectionFormat/main.cadl#L43) defines the return model as string, but mockapi.ts returns an object. It will cause strong type languages like java and .net can't convert return type to string in convenient method .

```typescript
op testMulti(...MultiCollectionFormatParameter): string;
```

2. update csv case

Reasons:

- https://www.rfc-editor.org/rfc/rfc3986#section-2.4 RFC does not have restriction for whether we do encoding. 

- I've also verified in Java, our existing DPG behavior (non-cadl one) will encode comma. The url would be: 
```
info: GET /collectionFormat/csv?colors=blue%2Cred%2Cgreen
```

- I saw the autorest.testserver [case](https://github.com/Azure/autorest.testserver/blob/79b23e5ebff1caca9dbda93a9220485331537e5f/swagger/url.json#L740) on csv format for header param will do the encoding. I think it would be better to make it consistent in both header and query param in csv collection format. 

So I make both encoding comma and not encoding be successful case. 


# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
