### PR TITLE
add test for `@overload` and multi content-type

### DIFF
--- a/.changeset/rude-pigs-own.md
+++ b/.changeset/rude-pigs-own.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+add test for overload

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1535,6 +1535,50 @@ Expected input body:
 }
 ```
 
+### Overload_uploadBytesOrString
+
+- Endpoint: `post /overload/bytesOrString`
+
+send "hello world" with `conten-type` "text/plain";
+send binary data "hello world" with `conten-type` "application/octet-stream"
+
+### Overload_uploadBytesOrStringSkip1
+
+- Endpoint: `post /overload/bytesOrString/skip1`
+
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+
+### Overload_uploadBytesOrStringSkip2
+
+- Endpoint: `post /overload/bytesOrString/skip2`
+
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+
+### Overload_uploadJsonOrString
+
+- Endpoint: `post /overload/JsonOrString`
+
+send "hello world" with `conten-type` "text/plain";
+send
+
+```json
+{ "hello": "world" }
+```
+
+with `conten-type` "application//json"
+
+### Overload_uploadJsonOrStringSkip3
+
+- Endpoint: `post /overload/JsonOrString/skip3`
+
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+
+### Overload_uploadJsonOrStringSkip4
+
+- Endpoint: `post /overload/JsonOrString/skip4`
+
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+
 ### ProjectedName_jsonProjection
 
 - Endpoint: `post /projection/json`

--- a/packages/cadl-ranch-specs/http/overload/main.cadl
+++ b/packages/cadl-ranch-specs/http/overload/main.cadl
@@ -1,0 +1,74 @@
+import "@cadl-lang/rest";
+import "@azure-tools/cadl-ranch-expect";
+
+using Cadl.Http;
+
+@doc("Overload")
+@supportedBy("dpg")
+@scenarioService("/overload")
+namespace Overload;
+
+@scenario
+@scenarioDoc("""
+send "hello world" with `conten-type` "text/plain";
+send binary data "hello world" with `conten-type` "application/octet-stream"
+""")
+@route("/bytesOrString")
+@post
+op uploadBytesOrString(
+  @body data: string | bytes,
+  @header contentType: "text/plain" | "application/octet-stream"
+): void;
+
+@scenario
+@scenarioDoc("""
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+""")
+@overload(uploadBytesOrString)
+@route("/bytesOrString/skip1")
+@post
+op uploadBytesOrStringSkip1(@body data: string, @header contentType: "text/plain"): void;
+
+@scenario
+@scenarioDoc("""
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+""")
+@overload(uploadBytesOrString)
+@route("/bytesOrString/skip2")
+@post
+op uploadBytesOrStringSkip2(@body data: bytes, @header contentType: "application/octet-stream"): void;
+
+model Data {
+  hello: string;
+}
+
+@scenario
+@scenarioDoc("""
+send "hello world" with `conten-type` "text/plain";
+send
+```json
+{ "hello": "world"}
+```
+with `conten-type` "application//json"
+""")
+@route("/JsonOrString")
+@post
+op uploadJsonOrString(@body data: string | Data, @header contentType: "text/plain" | "application/json"): void;
+
+@scenario
+@scenarioDoc("""
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+""")
+@overload(uploadJsonOrString)
+@route("/JsonOrString/skip3")
+@post
+op uploadJsonOrStringSkip3(@body data: string, @header contentType: "text/plain"): void;
+
+@scenario
+@scenarioDoc("""
+TODO: optimize cadl-ranch to skip it because the op is only for overload and no need to test
+""")
+@overload(uploadJsonOrString)
+@route("/JsonOrString/skip4")
+@post
+op uploadJsonOrStringSkip4(@body data: Data, @header contentType: "application/json"): void;

--- a/packages/cadl-ranch-specs/http/overload/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/overload/mockapi.ts
@@ -1,0 +1,72 @@
+import { passOnSuccess, mockapi } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Overload_uploadBytesOrString = passOnSuccess(
+  mockapi.post("/overload/bytesOrString", (req) => {
+    const contentType = req.headers["content-type"];
+    const reponse = { status: 204 };
+    if (contentType === "application/octet-stream") {
+      req.expect.bodyEquals(Buffer.from("hello world", "utf8"));
+      return reponse;
+    } else if (contentType === "text/plain") {
+      req.expect.bodyEquals("hello world");
+      return reponse;
+    } else {
+      return {
+        status: 400,
+      };
+    }
+  }),
+);
+
+Scenarios.Overload_uploadBytesOrStringSkip1 = passOnSuccess(
+  mockapi.post("/overload/bytesOrString/skip1", (req) => {
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.Overload_uploadBytesOrStringSkip2 = passOnSuccess(
+  mockapi.post("/overload/bytesOrString/skip2", (req) => {
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.Overload_uploadJsonOrString = passOnSuccess(
+  mockapi.post("/overload/JsonOrString", (req) => {
+    const contentType = req.headers["content-type"];
+    const reponse = { status: 204 };
+    if (contentType === "application/json") {
+      req.expect.bodyEquals({ hello: "world" });
+      return reponse;
+    } else if (contentType === "text/plain") {
+      req.expect.bodyEquals("hello world");
+      return reponse;
+    } else {
+      return {
+        status: 400,
+      };
+    }
+  }),
+);
+
+Scenarios.Overload_uploadJsonOrStringSkip3 = passOnSuccess(
+  mockapi.post("/overload/JsonOrString/skip3", (req) => {
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.Overload_uploadJsonOrStringSkip4 = passOnSuccess(
+  mockapi.post("/overload/JsonOrString/skip4", (req) => {
+    return {
+      status: 204,
+    };
+  }),
+);


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
