### PR TITLE
update azure core traits test

### DIFF
--- a/.changeset/afraid-plums-lay.md
+++ b/.changeset/afraid-plums-lay.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+remove api version test in azure core traits

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -752,7 +752,7 @@ Expected response body:
 }
 ```
 
-### Azure_Core_Traits_get
+### Azure_Core_Traits_smokeTest
 
 - Endpoint: `get /azure/core/traits`
 
@@ -777,22 +777,6 @@ Expected response body:
   "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
 }
 ```
-
-### Azure_Core_Traits_delete
-
-- Endpoint: `get /azure/core/traits`
-
-Expected path parameter:
-
-- id=1
-- api-version=2022-12-01-preview
-  Expected header parameters:
-- x-ms-client-request-id=<any string>
-
-Expected response headers:
-
-- x-ms-client-request-id=<any string>
-- Repeatability-Result=Accepted
 
 ### Dictionary_Int32Value_get
 

--- a/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
@@ -37,14 +37,6 @@ model User {
   name?: string;
 }
 
-@doc("The ApiVersion path parameter.")
-model ApiVersionPathParameter {
-  @segment("api")
-  @path("api-version")
-  @doc("The API version to use for this operation.")
-  apiVersion: string;
-}
-
 @scenario
 @doc("Get a resource, sending and receiving headers.")
 @scenarioDoc("""
@@ -68,7 +60,7 @@ Expected response body:
 }
 ```
 """)
-op get is OperationsWithTraits.ResourceRead<
+op smokeTest is OperationsWithTraits.ResourceRead<
   User,
   RequestHeadersTrait<{
     @doc("header in request")
@@ -79,18 +71,3 @@ op get is OperationsWithTraits.ResourceRead<
       @header bar: string;
     }>
 >;
-
-@scenario
-@doc("Delete resource with api-version path parameter")
-@scenarioDoc("""
-Expected path parameter:
-- id=1
-- api-version=2022-12-01-preview
-Expected header parameters:
-- x-ms-client-request-id=<any string>
-
-Expected response headers:
-- x-ms-client-request-id=<any string>
-- Repeatability-Result=Accepted
-""")
-op delete is OperationsWithTraits.ResourceDelete<User, TraitOverride<VersionParameterTrait<ApiVersionPathParameter>>>;

--- a/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
@@ -33,4 +33,3 @@ Scenarios.Azure_Core_Traits_smokeTest = passOnSuccess(
     };
   }),
 );
-

--- a/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
@@ -9,7 +9,7 @@ const validUser = {
   etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59",
 };
 
-Scenarios.Azure_Core_Traits_get = passOnSuccess(
+Scenarios.Azure_Core_Traits_smokeTest = passOnSuccess(
   mockapi.get("/azure/core/traits/user/:id", (req) => {
     if (!("x-ms-client-request-id" in req.headers)) {
       throw new ValidationError("Should submit header x-ms-client-request-id", "any uuid", undefined);
@@ -34,27 +34,3 @@ Scenarios.Azure_Core_Traits_get = passOnSuccess(
   }),
 );
 
-Scenarios.Azure_Core_Traits_delete = passOnSuccess(
-  mockapi.delete("/azure/core/traits/api/:apiVersion/user/:id", (req) => {
-    if (!("x-ms-client-request-id" in req.headers)) {
-      throw new ValidationError("Should submit header x-ms-client-request-id", "any uuid", undefined);
-    }
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    if (req.params.apiVersion !== "2022-12-01-preview") {
-      throw new ValidationError(
-        "Expected path param apiVersion=2022-12-01-preview",
-        "2022-12-01-preview",
-        req.params.apiVersion,
-      );
-    }
-    return {
-      status: 204,
-      headers: {
-        "x-ms-client-request-id": req.headers["x-ms-client-request-id"],
-        "Repeatability-Result": "Accepted",
-      },
-    };
-  }),
-);


### PR DESCRIPTION
remove azure core traits test that was resulting in two api version parameters, using it more as a smoke test of azure core traits since most of the testing for azure core traits should be handled higher up