### PR TITLE
Fix page key for value

### DIFF
--- a/.changeset/giant-mangos-check.md
+++ b/.changeset/giant-mangos-check.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Fix the page key for value

--- a/packages/cadl-ranch-specs/http/azure/core/basic/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/basic/mockapi.ts
@@ -77,7 +77,7 @@ Scenarios.Azure_Core_Basic_list = passOnSuccess(
 Scenarios.Azure_Core_Basic_listWithPage = passOnSuccess(
   mockapi.get("/azure/core/basic/page", (req) => {
     const responseBody = {
-      value: [validUser],
+      items: [validUser],
     };
     return { status: 200, body: json(responseBody) };
   }),


### PR DESCRIPTION
According to its spec
```
@global.Azure.Core.pagedResult
model CustomPageModel<T> {
  @global.Azure.Core.items
  @doc("List of items.")
  items: T[];

  @global.Azure.Core.nextLink
  @doc("Link to fetch more items.")
  nextLink?: string;
}
```

The key to get items should be "items".