### PR TITLE
Fix CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @timotheeguerin @iscai-msft @lmazuel @nguerrera @tjprescott
-packages/cadl-ranch-specs/http/* @iscai-msft @lmazuel @m-nash @joheredi @srnagar
+/packages/cadl-ranch-specs/http/* @iscai-msft @lmazuel @m-nash @joheredi @srnagar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @timotheeguerin @iscai-msft @lmazuel @nguerrera @tjprescott
-/packages/cadl-ranch-specs/http/* @iscai-msft @lmazuel @m-nash @joheredi @srnagar
+/packages/cadl-ranch-specs/http/ @iscai-msft @lmazuel @m-nash @joheredi @srnagar


### PR DESCRIPTION
Reading the doc, I'm missing a `/`

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax