### PR TITLE
Fix validating external op

### DIFF
--- a/.changeset/curvy-birds-accept.md
+++ b/.changeset/curvy-birds-accept.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-expect": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+Fix validation for presence of `@scenario` giving false positive when doing local link of Azure.Core package.

--- a/packages/cadl-ranch-expect/src/validate.ts
+++ b/packages/cadl-ranch-expect/src/validate.ts
@@ -1,7 +1,9 @@
 import {
   getSourceLocation,
   Interface,
+  isDeclaredInNamespace,
   isTemplateDeclaration,
+  listServices,
   Namespace,
   navigateProgram,
   Operation,
@@ -11,12 +13,14 @@ import { getScenarioDoc, getScenarioName } from "./decorators.js";
 import { reportDiagnostic } from "./lib.js";
 
 export function $onValidate(program: Program) {
+  const services = listServices(program);
   navigateProgram(program, {
     operation: (operation) => {
       if ((operation.interface && isTemplateDeclaration(operation.interface)) || isTemplateDeclaration(operation)) {
         return;
       }
-      if (getSourceLocation(operation).file.path.includes("/node_modules/")) {
+      //  If the scenario is not defined in one of the scenario service then we can ignore it.
+      if (!services.some((x) => isDeclaredInNamespace(operation, x.type))) {
         return;
       }
       const scenarioType = checkIsInScenario(program, operation);

--- a/packages/cadl-ranch-expect/src/validate.ts
+++ b/packages/cadl-ranch-expect/src/validate.ts
@@ -1,5 +1,4 @@
 import {
-  getSourceLocation,
   Interface,
   isDeclaredInNamespace,
   isTemplateDeclaration,


### PR DESCRIPTION
Not really a problem if running from within this repo but when doing the [smoke test in typespec-azure](https://github.com/Azure/typespec-azure/pull/2870) ignoring operations defined in node_modules is not reliable because the other ops might not be under node_modules but some local linked package

Change the logic to only include operation in the service(s) namespace(s)