### PR TITLE
Fix internal

### DIFF
--- a/.changeset/three-eagles-do.md
+++ b/.changeset/three-eagles-do.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+minor fix for internal test

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
@@ -54,7 +54,7 @@ Expected response body:
 @route("/internal")
 @get
 @global.Azure.ClientGenerator.Core.internal
-op internalOnly(@query name: string): PublicModel;
+op internalOnly(@query name: string): InternalModel;
 
 @route("/shared")
 @global.Azure.ClientGenerator.Core.operationGroup


### PR DESCRIPTION
@tadelesh fixed internalOnly op to use InternalModel

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
