### PR TITLE
Semi-auto release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - auto-publish
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -34,6 +33,7 @@ jobs:
 
       - name: Create release branch
         run: node ./eng/publish.mjs
+
       # - name: Create Release Pull Request
       #   uses: changesets/action@v1
       #   with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,11 @@
 name: Release
 
 # Disable as MS Org doesn't allow github action to create PR anymore. Can be re-added if a solution is found.
-# on:
-#   push:
-#     branches:
-#       - main
+on:
+  push:
+    branches:
+      - main
+      - auto-publish
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -31,12 +32,14 @@ jobs:
       - run: pnpm install
         name: Install dependencies
 
-      - name: Create Release Pull Request
-        uses: changesets/action@v1
-        with:
-          title: "Bump package versions for release"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create release branch
+        run: node ./eng/publish.mjs
+      # - name: Create Release Pull Request
+      #   uses: changesets/action@v1
+      #   with:
+      #     title: "Bump package versions for release"
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/
       # - name: Trigger CI

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ Go through [PR checklist](./.github/pull_request_template.md)
 
 ### Release a new version
 
+**Semi-auto:**
+
+Branch `publish/auto-release` should be automatically updated with the latest changelog. Give it 5min after merging a PR or check the status of the [Release action](https://github.com/Azure/cadl-ranch/actions/workflows/release.yml)
+
+Then go to https://github.com/Azure/cadl-ranch/pull/new/publish/auto-release and create this PR.
+
+**Manual**
+
 1. Run `pnpm changeset version` to bump the versions according to the changesets.
 2. Make a new branch called `publish/<xyz>`
 3. Make a PR and merge

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -1,0 +1,16 @@
+import { execSync } from "child_process";
+
+const branchName = "publish/auto-release";
+console.log("Checkout branch", branchName);
+try {
+  execSync(`git checkout -b ${branchName}`);
+} catch {
+  execSync(`git checkout ${branchName}`);
+}
+
+console.log("Branch checked out");
+
+execSync(`git reset --hard origin/main`);
+execSync(`pnpm changeset version`);
+execSync(`git commit -am "Bump versions"`);
+execSync(`git push --set-upstream origin ${branchName} --force`);

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -2,6 +2,8 @@ import { execSync } from "child_process";
 
 const branchName = "publish/auto-release";
 
+execSync(`git config --global user.email "noreply@microsoft.com"`);
+execSync(`git config --global user.name "Auto Changeset Bot"`);
 execSync(`pnpm changeset version`);
 execSync(`git commit -am "Bump versions"`);
 execSync(`git push --set-upstream origin ${branchName} --force`);

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -7,3 +7,9 @@ execSync(`git config --global user.name "Auto Changeset Bot"`);
 execSync(`pnpm changeset version`);
 execSync(`git commit -am "Bump versions"`);
 execSync(`git push origin HEAD:${branchName} --force`);
+
+console.log();
+console.log("-".repeat(160));
+console.log("|  Link to create the PR");
+console.log(`|  https://github.com/Azure/cadl-ranch/pull/new/${branchName}  `);
+console.log("-".repeat(160));

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -6,4 +6,4 @@ execSync(`git config --global user.email "noreply@microsoft.com"`);
 execSync(`git config --global user.name "Auto Changeset Bot"`);
 execSync(`pnpm changeset version`);
 execSync(`git commit -am "Bump versions"`);
-execSync(`git push --set-upstream origin ${branchName} --force`);
+execSync(`git push origin HEAD:${branchName} --force`);

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -1,16 +1,7 @@
 import { execSync } from "child_process";
 
 const branchName = "publish/auto-release";
-console.log("Checkout branch", branchName);
-try {
-  execSync(`git checkout -b ${branchName}`);
-} catch {
-  execSync(`git checkout ${branchName}`);
-}
 
-console.log("Branch checked out");
-
-execSync(`git reset --hard origin/main`);
 execSync(`pnpm changeset version`);
 execSync(`git commit -am "Bump versions"`);
 execSync(`git push --set-upstream origin ${branchName} --force`);


### PR DESCRIPTION
Automatically create the branch with the latest changelog. Which makes it that we only need to create the PR using the link given in the readme.