### PR TITLE
Fix format of if-match and if-none-match

### DIFF
--- a/.changeset/smooth-laws-sip.md
+++ b/.changeset/smooth-laws-sip.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Fix format of if-match and if-none-match

--- a/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
@@ -18,8 +18,8 @@ Scenarios.Azure_Core_Traits_smokeTest = passOnSuccess(
       throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }
     req.expect.containsHeader("foo", "123");
-    req.expect.containsHeader("if-match", "\"valid\"");
-    req.expect.containsHeader("if-none-match", "\"invalid\"");
+    req.expect.containsHeader("if-match", '"valid"');
+    req.expect.containsHeader("if-none-match", '"invalid"');
     req.expect.containsHeader("if-unmodified-since", "Fri, 26 Aug 2022 14:38:00 GMT");
     req.expect.containsHeader("if-modified-since", "Thu, 26 Aug 2021 14:38:00 GMT");
     return {

--- a/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/mockapi.ts
@@ -18,8 +18,8 @@ Scenarios.Azure_Core_Traits_smokeTest = passOnSuccess(
       throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }
     req.expect.containsHeader("foo", "123");
-    req.expect.containsHeader("if-match", "valid");
-    req.expect.containsHeader("if-none-match", "invalid");
+    req.expect.containsHeader("if-match", "\"valid\"");
+    req.expect.containsHeader("if-none-match", "\"invalid\"");
     req.expect.containsHeader("if-unmodified-since", "Fri, 26 Aug 2022 14:38:00 GMT");
     req.expect.containsHeader("if-modified-since", "Thu, 26 Aug 2021 14:38:00 GMT");
     return {


### PR DESCRIPTION
As described here: https://github.com/Azure/autorest.csharp/issues/3318#issuecomment-1523735825

The payload of "if-match" and "if-none-match" should have quotes wrapping the string.