### PR TITLE
Fix: Using template operations should use `alias` 

### DIFF
--- a/.changeset/four-hotels-unite.md
+++ b/.changeset/four-hotels-unite.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+Fix: Azure.Core test should use `alias` instead of interface extends for the operation factory

--- a/packages/cadl-ranch-specs/http/azure/core/basic/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/basic/main.tsp
@@ -25,8 +25,9 @@ enum Versions {
   v2022_12_01_preview: "2022-12-01-preview",
 }
 
-interface ResourceOperations
-  extends global.Azure.Core.ResourceOperations<NoConditionalRequests & NoRepeatableRequests & NoClientRequestId> {}
+alias ResourceOperations = global.Azure.Core.ResourceOperations<NoConditionalRequests &
+  NoRepeatableRequests &
+  NoClientRequestId>;
 
 @resource("users")
 @doc("Details about a user.")


### PR DESCRIPTION
Doing interface extends means all those operations are now included in this namespace.