### PR TITLE
add test for @encode on duration header

### DIFF
--- a/.changeset/violet-kings-matter.md
+++ b/.changeset/violet-kings-matter.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add test for @encode on duration header

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -585,6 +585,34 @@ Expected response body:
 }
 ```
 
+### Encode_Duration_Head_default
+
+- Endpoint: `get /encode/duration/head/default`
+
+Test default encode for a duration header.
+Expected query parameter `input=P40D`
+
+### Encode_Duration_Head_floatSeconds
+
+- Endpoint: `get /encode/duration/head/float-seconds`
+
+Test float seconds encode for a duration header.
+Expected header `duration: 35.621`
+
+### Encode_Duration_Head_int32Seconds
+
+- Endpoint: `get /encode/duration/head/int32-seconds`
+
+Test int32 seconds encode for a duration header.
+Expected header `duration: 36`
+
+### Encode_Duration_Head_iso8601
+
+- Endpoint: `get /encode/duration/head/iso8601`
+
+Test iso8601 encode for a duration header.
+Expected header `duration: P40D`
+
 ### Encode_Duration_Property_default
 
 - Endpoint: `post /encode/duration/property/default`

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -590,7 +590,7 @@ Expected response body:
 - Endpoint: `get /encode/duration/head/default`
 
 Test default encode for a duration header.
-Expected query parameter `input=P40D`
+Expected header `input=P40D`
 
 ### Encode_Duration_Head_floatSeconds
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -585,30 +585,30 @@ Expected response body:
 }
 ```
 
-### Encode_Duration_Head_default
+### Encode_Duration_Header_default
 
-- Endpoint: `get /encode/duration/head/default`
+- Endpoint: `get /encode/duration/header/default`
 
 Test default encode for a duration header.
 Expected header `input=P40D`
 
-### Encode_Duration_Head_floatSeconds
+### Encode_Duration_Header_floatSeconds
 
-- Endpoint: `get /encode/duration/head/float-seconds`
+- Endpoint: `get /encode/duration/header/float-seconds`
 
 Test float seconds encode for a duration header.
 Expected header `duration: 35.621`
 
-### Encode_Duration_Head_int32Seconds
+### Encode_Duration_Header_int32Seconds
 
-- Endpoint: `get /encode/duration/head/int32-seconds`
+- Endpoint: `get /encode/duration/header/int32-seconds`
 
 Test int32 seconds encode for a duration header.
 Expected header `duration: 36`
 
-### Encode_Duration_Head_iso8601
+### Encode_Duration_Header_iso8601
 
-- Endpoint: `get /encode/duration/head/iso8601`
+- Endpoint: `get /encode/duration/header/iso8601`
 
 Test iso8601 encode for a duration header.
 Expected header `duration: P40D`

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -163,8 +163,8 @@ namespace Property {
 }
 
 @operationGroup
-@route("/head")
-namespace Head {
+@route("/header")
+namespace Header {
   @route("/default")
   @scenario
   @scenarioDoc("""

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -183,7 +183,7 @@ namespace Header {
   Expected header `duration: P40D`
   """)
   op iso8601(
-    @query
+    @header
     @encode(DurationKnownEncoding.ISO8601)
     duration: duration
   ): NoContentResponse;
@@ -195,7 +195,7 @@ namespace Header {
   Expected header `duration: 36`
   """)
   op int32Seconds(
-    @query
+    @header
     @encode(DurationKnownEncoding.seconds, int32)
     duration: duration
   ): NoContentResponse;
@@ -207,7 +207,7 @@ namespace Header {
   Expected header `duration: 35.621`
   """)
   op floatSeconds(
-    @query
+    @header
     @encode(DurationKnownEncoding.seconds, float)
     duration: duration
   ): NoContentResponse;

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -169,7 +169,7 @@ namespace Head {
   @scenario
   @scenarioDoc("""
   Test default encode for a duration header.
-  Expected query parameter `input=P40D`
+  Expected header `input=P40D`
   """)
   op default(
     @header

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -161,3 +161,54 @@ namespace Property {
   """)
   op floatSeconds(@body body: FloatSecondsDurationProperty): FloatSecondsDurationProperty;
 }
+
+@operationGroup
+@route("/head")
+namespace Head {
+  @route("/default")
+  @scenario
+  @scenarioDoc("""
+  Test default encode for a duration header.
+  Expected query parameter `input=P40D`
+  """)
+  op default(
+    @header
+    duration: duration
+  ): NoContentResponse;
+
+  @route("/iso8601")
+  @scenario
+  @scenarioDoc("""
+  Test iso8601 encode for a duration header.
+  Expected header `duration: P40D`
+  """)
+  op iso8601(
+    @query
+    @encode(DurationKnownEncoding.ISO8601)
+    duration: duration
+  ): NoContentResponse;
+
+  @route("/int32-seconds")
+  @scenario
+  @scenarioDoc("""
+  Test int32 seconds encode for a duration header.
+  Expected header `duration: 36`
+  """)
+  op int32Seconds(
+    @query
+    @encode(DurationKnownEncoding.seconds, int32)
+    duration: duration
+  ): NoContentResponse;
+
+  @route("/float-seconds")
+  @scenario
+  @scenarioDoc("""
+  Test float seconds encode for a duration header.
+  Expected header `duration: 35.621`
+  """)
+  op floatSeconds(
+    @query
+    @encode(DurationKnownEncoding.seconds, float)
+    duration: duration
+  ): NoContentResponse;
+}

--- a/packages/cadl-ranch-specs/http/encode/duration/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/duration/mockapi.ts
@@ -24,6 +24,16 @@ function createPropertyMockApis(route: string, value: any): MockApi {
   });
 }
 
+function createHeaderMockApis(route: string, value: any): MockApi {
+  const url = `/encode/duration/header/${route}`;
+  return mockapi.get(url, (req) => {
+    req.expect.containsHeader("duration", value);
+    return {
+      status: 204,
+    };
+  });
+}
+
 Scenarios.Encode_Duration_Query_default = passOnSuccess(createQueryMockApis("default", "P40D"));
 Scenarios.Encode_Duration_Query_iso8601 = passOnSuccess(createQueryMockApis("iso8601", "P40D"));
 Scenarios.Encode_Duration_Query_int32Seconds = passOnSuccess(createQueryMockApis("int32-seconds", "36"));
@@ -33,3 +43,8 @@ Scenarios.Encode_Duration_Property_default = passOnSuccess(createPropertyMockApi
 Scenarios.Encode_Duration_Property_iso8601 = passOnSuccess(createPropertyMockApis("iso8601", "P40D"));
 Scenarios.Encode_Duration_Property_int32Seconds = passOnSuccess(createPropertyMockApis("int32-seconds", 36));
 Scenarios.Encode_Duration_Property_floatSeconds = passOnSuccess(createPropertyMockApis("float-seconds", 35.621));
+
+Scenarios.Encode_Duration_Header_default = passOnSuccess(createHeaderMockApis("default", "P40D"));
+Scenarios.Encode_Duration_Header_iso8601 = passOnSuccess(createHeaderMockApis("iso8601", "P40D"));
+Scenarios.Encode_Duration_Header_int32Seconds = passOnSuccess(createHeaderMockApis("int32-seconds", "36"));
+Scenarios.Encode_Duration_Header_floatSeconds = passOnSuccess(createHeaderMockApis("float-seconds", "35.621"));


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.

resolve: #324