### PR TITLE
Update code owners to add engineers from SH team.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @timotheeguerin @iscai-msft @lmazuel @nguerrera @tjprescott
-/packages/cadl-ranch-specs/http/ @iscai-msft @lmazuel @m-nash @joheredi @srnagar
+* @timotheeguerin @iscai-msft @lmazuel @nguerrera @tjprescott @weidongxu-microsoft
+/packages/cadl-ranch-specs/http/ @iscai-msft @lmazuel @m-nash @joheredi @srnagar @weidongxu-microsoft @tadelesh


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

Update code owners to add Chenjie Shi and Weidong Xu.