### PR TITLE
fix wrong header check for custom http

### DIFF
--- a/.changeset/cold-carrots-argue.md
+++ b/.changeset/cold-carrots-argue.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix wrong header check for custom http

--- a/packages/cadl-ranch-specs/http/authentication/http/custom/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/authentication/http/custom/mockapi.ts
@@ -8,7 +8,7 @@ const validAndInvalidScenarios = getValidAndInvalidScenarios(
   "http/custom",
   "invalid-api-key",
   function addOptionalParamOldApiVersionNewClientValidate(req: MockRequest): void {
-    req.expect.containsHeader("Authorization", "SharedAccessKey valid-key");
+    req.expect.containsHeader("authorization", "SharedAccessKey valid-key");
   },
 );
 


### PR DESCRIPTION
Minor issue from https://github.com/Azure/cadl-ranch/pull/262