### PR TITLE
Fix action mock api

### DIFF
--- a/.changeset/serious-bees-lie.md
+++ b/.changeset/serious-bees-lie.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+Escape colon in POST url

--- a/packages/cadl-ranch-specs/http/azure/core/basic/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/basic/mockapi.ts
@@ -103,7 +103,7 @@ Scenarios.Azure_Core_Basic_delete = passOnSuccess(
 );
 
 Scenarios.Azure_Core_Basic_export = passOnSuccess(
-  mockapi.post("/azure/core/basic/users/:id:export", (req) => {
+  mockapi.post("/azure/core/basic/users/:id[:]export", (req) => {
     if (req.params.id !== "1") {
       throw new ValidationError("Expected path param id=1", "1", req.params.id);
     }


### PR DESCRIPTION
Colon used in action POST url should be escaped, so JS do not take it for a name to match