### PR TITLE
Add test for @include over @internal

### DIFF
--- a/.changeset/nine-otters-change.md
+++ b/.changeset/nine-otters-change.md
@@ -2,4 +2,4 @@
 "@azure-tools/cadl-ranch-specs": patch
 ---
 
-Add test for @include over @internal
+Add test for `@include` over `@internal`

--- a/.changeset/nine-otters-change.md
+++ b/.changeset/nine-otters-change.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add test for @include over @internal

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -85,6 +85,24 @@ Expected response body:
 }
 ```
 
+### Azure_ClientGenerator_Core_Internal_postInternalOnly
+
+- Endpoint: `post /azure/client-generator-core/internal/internal`
+
+This scenario contains an internal operation. It should be generated but not exposed.
+Expected body parameter:
+
+````json
+{
+  "name": <any string>
+}
+Expected response body:
+```json
+{
+  "result": <any string>
+}
+````
+
 ### Azure_ClientGenerator_Core_Internal_publicOnly
 
 - Endpoint: `get /azure/client-generator-core/internal/public`

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -85,7 +85,7 @@ Expected response body:
 }
 ```
 
-### Azure_ClientGenerator_Core_Internal_postInternalOnly
+### Azure_ClientGenerator_Core_Internal_internalWithIncludeModel
 
 - Endpoint: `post /azure/client-generator-core/internal/internal`
 
@@ -99,7 +99,7 @@ Expected body parameter:
 Expected response body:
 ```json
 {
-  "result": <any string>
+  "name": <any string>
 }
 ````
 

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
@@ -27,6 +27,7 @@ model InternalIncludeModel {
   nested: NestedIncludeModel;
 }
 
+@doc("This is a model referred by model decorated with @include. It should be generated and exported.")
 model NestedIncludeModel {
   comment: string;
 }

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
@@ -24,6 +24,11 @@ model InternalModel {
 @global.Azure.ClientGenerator.Core.include
 model InternalIncludeModel {
   name: string;
+  nested: NestedIncludeModel;
+}
+
+model NestedIncludeModel {
+  comment: string;
 }
 
 @doc("This is a model used by both public and internal operation. It should be generated and exported.")

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
@@ -20,6 +20,12 @@ model InternalModel {
   name: string;
 }
 
+@doc("This is a model only used by internal operation. Also, it is decorated with @include. It should be generated and exported.")
+@global.Azure.ClientGenerator.Core.include
+model InternaIncludelModel {
+  name: string;
+}
+
 @doc("This is a model used by both public and internal operation. It should be generated and exported.")
 model SharedModel {
   name: string;
@@ -55,6 +61,26 @@ Expected response body:
 @get
 @global.Azure.ClientGenerator.Core.internal
 op internalOnly(@query name: string): InternalModel;
+
+@scenario
+@scenarioDoc("""
+This scenario contains an internal operation. It should be generated but not exposed.
+Expected body parameter:
+```json
+{
+  "name": <any string>
+}
+Expected response body:
+```json
+{
+  "result": <any string>
+}
+```
+""")
+@route("/internal")
+@post
+@global.Azure.ClientGenerator.Core.internal
+op postInternalOnly(@body body: InternalModel): InternaIncludelModel;
 
 @route("/shared")
 @global.Azure.ClientGenerator.Core.operationGroup

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/main.tsp
@@ -22,7 +22,7 @@ model InternalModel {
 
 @doc("This is a model only used by internal operation. Also, it is decorated with @include. It should be generated and exported.")
 @global.Azure.ClientGenerator.Core.include
-model InternaIncludelModel {
+model InternalIncludeModel {
   name: string;
 }
 
@@ -73,14 +73,14 @@ Expected body parameter:
 Expected response body:
 ```json
 {
-  "result": <any string>
+  "name": <any string>
 }
 ```
 """)
 @route("/internal")
 @post
 @global.Azure.ClientGenerator.Core.internal
-op postInternalOnly(@body body: InternalModel): InternaIncludelModel;
+op internalWithIncludeModel(@body body: InternalIncludeModel): InternalIncludeModel;
 
 @route("/shared")
 @global.Azure.ClientGenerator.Core.operationGroup

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/mockapi.ts
@@ -28,7 +28,7 @@ Scenarios.Azure_ClientGenerator_Core_Internal_postInternalOnly = passOnSuccess(
     req.expect.bodyNotEmpty();
     return {
       status: 200,
-      body: json({ result: req.body["name"] }),
+      body: json({ name: req.body["name"] }),
     };
   }),
 );

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/mockapi.ts
@@ -3,7 +3,7 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-function createInternalMockApis(route: string): MockApi {
+function createInternalGetMockApis(route: string): MockApi {
   const url = `/azure/client-generator-core/internal/${route}`;
   return mockapi.get(url, (req) => {
     if (!("name" in req.query)) {
@@ -16,9 +16,19 @@ function createInternalMockApis(route: string): MockApi {
   });
 }
 
-Scenarios.Azure_ClientGenerator_Core_Internal_publicOnly = passOnSuccess(createInternalMockApis("public"));
-Scenarios.Azure_ClientGenerator_Core_Internal_internalOnly = passOnSuccess(createInternalMockApis("internal"));
+Scenarios.Azure_ClientGenerator_Core_Internal_publicOnly = passOnSuccess(createInternalGetMockApis("public"));
+Scenarios.Azure_ClientGenerator_Core_Internal_internalOnly = passOnSuccess(createInternalGetMockApis("internal"));
 Scenarios.Azure_ClientGenerator_Core_Internal_Shared = passOnSuccess([
-  createInternalMockApis("shared/public"),
-  createInternalMockApis("shared/internal"),
+  createInternalGetMockApis("shared/public"),
+  createInternalGetMockApis("shared/internal"),
 ]);
+
+Scenarios.Azure_ClientGenerator_Core_Internal_postInternalOnly = passOnSuccess(
+  mockapi.post("/azure/client-generator-core/internal/internal", (req) => {
+    req.expect.bodyNotEmpty();
+    return {
+      status: 200,
+      body: json({ result: req.body["name"] }),
+    };
+  }),
+);

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/internal/mockapi.ts
@@ -23,7 +23,7 @@ Scenarios.Azure_ClientGenerator_Core_Internal_Shared = passOnSuccess([
   createInternalGetMockApis("shared/internal"),
 ]);
 
-Scenarios.Azure_ClientGenerator_Core_Internal_postInternalOnly = passOnSuccess(
+Scenarios.Azure_ClientGenerator_Core_Internal_internalWithIncludeModel = passOnSuccess(
   mockapi.post("/azure/client-generator-core/internal/internal", (req) => {
     req.expect.bodyNotEmpty();
     return {


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.


This test is from openai real use case: https://github.com/Azure/autorest.csharp/issues/3519. The new added test could not be tested by mock server, different languages' SDK should add test for their generated code.
The logic emitter should accomplish:
1. `isInternal` will return `true` for `InternaIncludelModel` model
2. `isInclude` will return `true` for `InternaIncludelModel` model
3. `InternaIncludelModel` will be included in `getAllModels`
4. SDK should generate `InternaIncludelModel` and make it public to user.