### PR TITLE
fix(mock): inconsistent status code

### DIFF
--- a/.changeset/fluffy-chairs-taste.md
+++ b/.changeset/fluffy-chairs-taste.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix(mock): inconsistent status code

--- a/packages/cadl-ranch-specs/http/type/model/inheritance/not-discriminated/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/model/inheritance/not-discriminated/mockapi.ts
@@ -7,7 +7,7 @@ const inheritanceValidBody = { name: "abc", age: 32, smart: true };
 Scenarios.Type_Model_Inheritance_NotDiscriminated_postValid = passOnSuccess(
   mockapi.post("/type/model/inheritance/not-discriminated/valid", (req) => {
     req.expect.bodyEquals(inheritanceValidBody);
-    return { status: 200 };
+    return { status: 204 };
   }),
 );
 


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
