### PR TITLE
change cli parameter name to use-peer-ranges

### DIFF
--- a/.changeset/spotty-cats-matter.md
+++ b/.changeset/spotty-cats-matter.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/typespec-bump-deps": minor
+---
+
+change cli parameter name to use-peer-ranges

--- a/packages/typespec-bump-deps/src/cli/typespec-bump-deps.ts
+++ b/packages/typespec-bump-deps/src/cli/typespec-bump-deps.ts
@@ -37,7 +37,7 @@ export async function main() {
     "add-npm-overrides": {
       type: "boolean",
     },
-    "keep-ranges": {
+    "use-peer-ranges": {
       type: "boolean",
     },
   } as const;
@@ -47,7 +47,7 @@ export async function main() {
   const packageJsonPaths = positionals;
   const addRushOverrides = values["add-rush-overrides"] ?? false;
   const addNpmOverrides = values["add-npm-overrides"] ?? false;
-  const keepRanges = values["keep-ranges"] ?? false;
+  const usePeerRanges = values["use-peer-ranges"] ?? false;
 
   const packageToVersionRecord = Object.fromEntries(
     await Promise.all(knownPackages.map(async (x) => [x, await getKnownPackageVersion(x)])),
@@ -62,7 +62,7 @@ export async function main() {
     const content = await readFile(packageJsonPath);
     const packageJson = JSON.parse(content.toString());
 
-    updatePackageJson(packageJson, packageToVersionRecord, keepRanges, addNpmOverrides, addRushOverrides);
+    updatePackageJson(packageJson, packageToVersionRecord, usePeerRanges, addNpmOverrides, addRushOverrides);
 
     // eslint-disable-next-line no-console
     console.log(`Updated ${packageJsonPath}`);
@@ -73,7 +73,7 @@ export async function main() {
 export function updatePackageJson(
   packageJson: any,
   packageToVersionRecord: { [key: string]: string },
-  keepRanges: boolean,
+  usePeerRanges: boolean,
   addNpmOverrides: boolean,
   addRushOverrides: boolean,
 ) {
@@ -89,7 +89,7 @@ export function updatePackageJson(
   }
 
   for (const [packageName, version] of Object.entries(packageToVersionRecord)) {
-    if (keepRanges) {
+    if (usePeerRanges) {
       const peerDependency = packageJson.peerDependencies ? packageJson.peerDependencies[packageName] : undefined;
 
       if (peerDependency) {

--- a/packages/typespec-bump-deps/test/typespec-bump-deps.test.ts
+++ b/packages/typespec-bump-deps/test/typespec-bump-deps.test.ts
@@ -29,7 +29,7 @@ describe("typespec-bump-deps cli", () => {
       updatePackageJson(
         packageJson,
         packageToVersionRecord,
-        false, // keepRanges
+        false, // usePeerRanges
         false, // addNpmOverrides
         false, // addRushOverrides
       );
@@ -62,7 +62,7 @@ describe("typespec-bump-deps cli", () => {
       updatePackageJson(
         packageJson,
         packageToVersionRecord,
-        false, // keepRanges
+        false, // usePeerRanges
         true, // addNpmOverrides
         false, // addRushOverrides
       );
@@ -87,11 +87,11 @@ describe("typespec-bump-deps cli", () => {
         "package-c": "4.0.0",
       };
 
-      const keepRanges = false;
+      const usePeerRanges = false;
       const addNpmOverrides = false;
       const addRushOverrides = true;
 
-      updatePackageJson(packageJson, packageToVersionRecord, keepRanges, addNpmOverrides, addRushOverrides);
+      updatePackageJson(packageJson, packageToVersionRecord, usePeerRanges, addNpmOverrides, addRushOverrides);
 
       expect(packageJson).to.deep.equal({
         dependencies: {},
@@ -103,7 +103,7 @@ describe("typespec-bump-deps cli", () => {
       });
     });
 
-    describe("when keepRanges == true", () => {
+    describe("when usePeerRanges == true", () => {
       it("should use version ranges for peerDependencies", () => {
         const packageJson = {
           peerDependencies: {
@@ -121,7 +121,7 @@ describe("typespec-bump-deps cli", () => {
         updatePackageJson(
           packageJson,
           packageToVersionRecord,
-          true, // keepRanges
+          true, // usePeerRanges
           false, // addNpmOverrides
           false, // addRushOverrides
         );
@@ -151,7 +151,7 @@ describe("typespec-bump-deps cli", () => {
         updatePackageJson(
           packageJson,
           packageToVersionRecord,
-          true, // keepRanges
+          true, // usePeerRanges
           false, // addNpmOverrides
           false, // addRushOverrides
         );
@@ -185,7 +185,7 @@ describe("typespec-bump-deps cli", () => {
           updatePackageJson(
             packageJson,
             packageToVersionRecord,
-            true, // keepRanges
+            true, // usePeerRanges
             false, // addNpmOverrides
             false, // addRushOverrides
           );


### PR DESCRIPTION
The parameter no longer matches the action.  `keep-ranges` implies that ranges in versions will be kept if they already exist.  With the current functionality, the flag will cause version ranges to be used even if they aren't currently used.