### PR TITLE
Rename and fix the "release" workflow to "Prepare Auto Release Branch"

### DIFF
--- a/.github/workflows/prepare-auto-release-branch.yml
+++ b/.github/workflows/prepare-auto-release-branch.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Prepare Auto Release Branch
 
 # Disable as MS Org doesn't allow github action to create PR anymore. Can be re-added if a solution is found.
 on:

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -12,12 +12,12 @@ if (stdout.trim() !== "") {
 
   execSync(`git commit -am "Bump versions"`);
   execSync(`git push origin HEAD:${branchName} --force`);
+
+  console.log();
+  console.log("-".repeat(160));
+  console.log("|  Link to create the PR");
+  console.log(`|  https://github.com/Azure/cadl-ranch/pull/new/${branchName}  `);
+  console.log("-".repeat(160));
 } else {
   console.log("No changes to publish");
 }
-
-console.log();
-console.log("-".repeat(160));
-console.log("|  Link to create the PR");
-console.log(`|  https://github.com/Azure/cadl-ranch/pull/new/${branchName}  `);
-console.log("-".repeat(160));

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -5,8 +5,16 @@ const branchName = "publish/auto-release";
 execSync(`git config --global user.email "autochangesetbot@microsoft.com"`);
 execSync(`git config --global user.name "Microsoft Auto Changeset Bot"`);
 execSync(`pnpm changeset version`);
-execSync(`git commit -am "Bump versions"`);
-execSync(`git push origin HEAD:${branchName} --force`);
+const stdout = execSync(`git status --porcelain`).toString();
+
+if (stdout.trim() !== "") {
+  console.log("Commiting the following changes:\n", stdout);
+
+  execSync(`git commit -am "Bump versions"`);
+  execSync(`git push origin HEAD:${branchName} --force`);
+} else {
+  console.log("No changes to publish");
+}
 
 console.log();
 console.log("-".repeat(160));


### PR DESCRIPTION
It was confusing as it was failing right after merging the auto release branch as there is no changelog