### PR TITLE
spec, add test case for pageable, focus on maxpagesize and nextLink

### DIFF
--- a/.changeset/red-donkeys-push.md
+++ b/.changeset/red-donkeys-push.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add test case for pageable and nextLink

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1412,6 +1412,49 @@ Scenario that returns a different file encoding depending on the accept header.
 - image/png return a png image
 - image/jpeg return a jpeg image
 
+### Payload_Pageable_list
+
+- Endpoint: `get /payload/pageable`
+
+List users.
+
+Expected query parameter:
+skip=5
+maxpagesize=3
+
+Expected response body:
+
+```json
+{
+  "value": [
+    {
+      "name": "user5"
+    },
+    {
+      "name": "user6"
+    },
+    {
+      "name": "user7"
+    }
+  ],
+  "nextLink": "{endpoint}//payload/pageable?skip=8&maxpagesize=3"
+}
+```
+
+Expected query parameter:
+skip=8
+maxpagesize=3
+
+```json
+{
+  "value": [
+    {
+      "name": "user8"
+    }
+  ]
+}
+```
+
 ### Projection_ProjectedName_operation
 
 - Endpoint: `post /projection/projected-name/operation`

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1418,6 +1418,8 @@ Scenario that returns a different file encoding depending on the accept header.
 
 List users.
 
+SDK may hide the "maxpagesize" from API signature. The functionality of "maxpagesize" could be in related language Page model.
+
 Expected query parameter:
 skip=5
 maxpagesize=3

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1421,7 +1421,6 @@ List users.
 SDK may hide the "maxpagesize" from API signature. The functionality of "maxpagesize" could be in related language Page model.
 
 Expected query parameter:
-skip=5
 maxpagesize=3
 
 Expected response body:
@@ -1439,12 +1438,12 @@ Expected response body:
       "name": "user7"
     }
   ],
-  "nextLink": "{endpoint}//payload/pageable?skip=8&maxpagesize=3"
+  "nextLink": "{endpoint}//payload/pageable?skipToken=name-user7&maxpagesize=3"
 }
 ```
 
 Expected query parameter:
-skip=8
+skipToken=name-user7
 maxpagesize=3
 
 ```json

--- a/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
@@ -1,6 +1,6 @@
 import "@azure-tools/cadl-ranch-expect";
 import "@azure-tools/typespec-azure-core";
-import "@typespec/versioning"
+import "@typespec/versioning";
 
 using TypeSpec.Versioning;
 using Azure.Core;
@@ -12,7 +12,7 @@ using Azure.Core;
 namespace Payload.Pageable;
 
 model User {
-  name: string
+  name: string;
 }
 
 @scenario

--- a/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
@@ -22,6 +22,8 @@ model User {
 @scenarioDoc("""
 List users.
 
+SDK may hide the "maxpagesize" from API signature. The functionality of "maxpagesize" could be in related language Page model.
+
 Expected query parameter:
 skip=5
 maxpagesize=3

--- a/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
@@ -25,7 +25,6 @@ List users.
 SDK may hide the "maxpagesize" from API signature. The functionality of "maxpagesize" could be in related language Page model.
 
 Expected query parameter:
-skip=5
 maxpagesize=3
 
 Expected response body:
@@ -42,12 +41,12 @@ Expected response body:
       "name":"user7"
     }
   ],
-  "nextLink": "{endpoint}//payload/pageable?skip=8&maxpagesize=3"
+  "nextLink": "{endpoint}//payload/pageable?skipToken=name-user7&maxpagesize=3"
 }
 ```
 
 Expected query parameter:
-skip=8
+skipToken=name-user7
 maxpagesize=3
 
 ```json
@@ -61,4 +60,4 @@ maxpagesize=3
 ```
 """)
 @doc("List users")
-op list(...SkipQueryParameter, ...MaxPageSizeQueryParameter): Page<User>;
+op list(...MaxPageSizeQueryParameter): Page<User>;

--- a/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
@@ -1,0 +1,60 @@
+import "@azure-tools/cadl-ranch-expect";
+import "@azure-tools/typespec-azure-core";
+import "@typespec/versioning"
+
+using TypeSpec.Versioning;
+using Azure.Core;
+
+@doc("Test describing pageable.")
+@supportedBy("dpg")
+@scenarioService("/payload/pageable")
+@useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+namespace Payload.Pageable;
+
+model User {
+  name: string
+}
+
+@scenario
+@scenarioDoc("""
+List users.
+
+Expected query parameter:
+top=100
+skip=5
+maxpagesize=3
+
+Expected response body:
+```json
+{
+  "value":[
+    {
+      "name":"user5"
+    },
+    {
+      "name":"user6"
+    },
+    {
+      "name":"user7"
+    }
+  ],
+  "nextLink": "{endpoint}//payload/pageable?top=100&skip=8&maxpagesize=3"
+}
+```
+
+Expected query parameter:
+top=100
+skip=8
+maxpagesize=3
+
+```json
+{
+  "value":[
+    {
+      "name":"user8"
+    }
+  ]
+}
+```
+""")
+op list(...StandardListQueryParameters): Page<User>;

--- a/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/pageable/main.tsp
@@ -11,16 +11,18 @@ using Azure.Core;
 @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
 namespace Payload.Pageable;
 
+@doc("User model")
 model User {
+  @doc("User name")
   name: string;
 }
 
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing pageable"
 @scenario
 @scenarioDoc("""
 List users.
 
 Expected query parameter:
-top=100
 skip=5
 maxpagesize=3
 
@@ -38,12 +40,11 @@ Expected response body:
       "name":"user7"
     }
   ],
-  "nextLink": "{endpoint}//payload/pageable?top=100&skip=8&maxpagesize=3"
+  "nextLink": "{endpoint}//payload/pageable?skip=8&maxpagesize=3"
 }
 ```
 
 Expected query parameter:
-top=100
 skip=8
 maxpagesize=3
 
@@ -57,4 +58,5 @@ maxpagesize=3
 }
 ```
 """)
-op list(...StandardListQueryParameters): Page<User>;
+@doc("List users")
+op list(...SkipQueryParameter, ...MaxPageSizeQueryParameter): Page<User>;

--- a/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
@@ -1,4 +1,4 @@
-import { mockapi, json, withKeys } from "@azure-tools/cadl-ranch-api";
+import { mockapi, json, withKeys, ValidationError } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
@@ -7,21 +7,28 @@ Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
   mockapi.get("/payload/pageable", (req) => {
     req.expect.containsQueryParam("top", "100");
     req.expect.containsQueryParam("maxpagesize", "3");
-    switch (req.query("skip")) {
+    switch (req.query["skip"]) {
       case "5":
         return {
+          pass: "firstPage",
+
           status: 200,
-          body: json({ value: [ {name: "user5"}, {name: "user6"}, {name: "user7"}], nextLink: `${req.baseUrl}//payload/pageable?top=100&skip=8&maxpagesize=3` }),
+          body: json({
+            value: [{ name: "user5" }, { name: "user6" }, { name: "user7" }],
+            nextLink: `${req.baseUrl}/payload/pageable?top=100&skip=8&maxpagesize=3`,
+          }),
         } as const;
-    
+
       case "8":
         return {
+          pass: "secondPage",
+
           status: 200,
-          body: json({ value: [ {name: "user8"}] }),
+          body: json({ value: [{ name: "user8" }] }),
         } as const;
-    
+
       default:
-        throw new ValidationError("Unsupported skip query parameter", `"5" | "8"`, req.query("skip"));
-      }
-  })
+        throw new ValidationError("Unsupported skip query parameter", `"5" | "8"`, req.query["skip"]);
+    }
+  }),
 );

--- a/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
@@ -6,32 +6,30 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
   mockapi.get("/payload/pageable", (req) => {
     req.expect.containsQueryParam("maxpagesize", "3");
-    switch (req.query["skip"]) {
-      case "5":
-        return {
-          pass: "firstPage",
+    const skipToken = req.query["skipToken"];
+    if (skipToken === undefined) {
+      return {
+        pass: "firstPage",
 
-          status: 200,
-          body: json({
-            value: [{ name: "user5" }, { name: "user6" }, { name: "user7" }],
-            nextLink: `${req.baseUrl}/payload/pageable?skip=8&maxpagesize=3`,
-          }),
-        } as const;
+        status: 200,
+        body: json({
+          value: [{ name: "user5" }, { name: "user6" }, { name: "user7" }],
+          nextLink: `${req.baseUrl}/payload/pageable?skipToken=name-user7&maxpagesize=3`,
+        }),
+      } as const;
+    } else if (skipToken === "name-user7") {
+      return {
+        pass: "secondPage",
 
-      case "8":
-        return {
-          pass: "secondPage",
-
-          status: 200,
-          body: json({ value: [{ name: "user8" }] }),
-        } as const;
-
-      default:
-        throw new ValidationError(
-          "Unsupported skip query parameter",
-          `"5" for first page, "8" for second page`,
-          req.query["skip"],
-        );
+        status: 200,
+        body: json({ value: [{ name: "user8" }] }),
+      } as const;
+    } else {
+      throw new ValidationError(
+        "Unsupported skipToken query parameter",
+        `Not provided for first page, "name-user7" for second page`,
+        req.query["skipToken"],
+      );
     }
   }),
 );

--- a/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
@@ -1,0 +1,27 @@
+import { mockapi, json, withKeys } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
+  mockapi.get("/payload/pageable", (req) => {
+    req.expect.containsQueryParam("top", "100");
+    req.expect.containsQueryParam("maxpagesize", "3");
+    switch (req.query("skip")) {
+      case "5":
+        return {
+          status: 200,
+          body: json({ value: [ {name: "user5"}, {name: "user6"}, {name: "user7"}], nextLink: `${req.baseUrl}//payload/pageable?top=100&skip=8&maxpagesize=3` }),
+        } as const;
+    
+      case "8":
+        return {
+          status: 200,
+          body: json({ value: [ {name: "user8"}] }),
+        } as const;
+    
+      default:
+        throw new ValidationError("Unsupported skip query parameter", `"5" | "8"`, req.query("skip"));
+      }
+  })
+);

--- a/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
@@ -5,7 +5,6 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
   mockapi.get("/payload/pageable", (req) => {
-    req.expect.containsQueryParam("top", "100");
     req.expect.containsQueryParam("maxpagesize", "3");
     switch (req.query["skip"]) {
       case "5":
@@ -15,7 +14,7 @@ Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
           status: 200,
           body: json({
             value: [{ name: "user5" }, { name: "user6" }, { name: "user7" }],
-            nextLink: `${req.baseUrl}/payload/pageable?top=100&skip=8&maxpagesize=3`,
+            nextLink: `${req.baseUrl}/payload/pageable?skip=8&maxpagesize=3`,
           }),
         } as const;
 
@@ -28,7 +27,7 @@ Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
         } as const;
 
       default:
-        throw new ValidationError("Unsupported skip query parameter", `"5" | "8"`, req.query["skip"]);
+        throw new ValidationError("Unsupported skip query parameter", `"5" for first page, "8" for second page`, req.query["skip"]);
     }
   }),
 );

--- a/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/pageable/mockapi.ts
@@ -27,7 +27,11 @@ Scenarios.Payload_Pageable_list = withKeys(["firstPage", "secondPage"]).pass(
         } as const;
 
       default:
-        throw new ValidationError("Unsupported skip query parameter", `"5" for first page, "8" for second page`, req.query["skip"]);
+        throw new ValidationError(
+          "Unsupported skip query parameter",
+          `"5" for first page, "8" for second page`,
+          req.query["skip"],
+        );
     }
   }),
 );


### PR DESCRIPTION
I currently put the test case in payload folder, as part of it tests the `nextLink`.

Though another part of the test is on `maxpagesize` query parameter (and emitter's handling of it).

---

PS: later we may add another case here, as pageable but without `nextLink` in response. We saw some backend write this (if new service, API would likely advise them to add `nextLink` just not send it; not able to do this to old service).
```ts
@pagedResult
model Page {
  @items
  value: Resource[];
}
```

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
