### PR TITLE
add test case for encode in response header

### DIFF
--- a/.changeset/new-ways-juggle.md
+++ b/.changeset/new-ways-juggle.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+add test case for encode in response header

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1112,6 +1112,38 @@ Test unixTimestamp encode for datetime array query parameter.
 Expected query parameter:
 value=1686566864, 1686734256
 
+### Encode_Datetime_ResponseHeader_default
+
+- Endpoint: `get /encode/datetime/responseheader/default`
+
+Test default encode (rfc7231) for datetime header.
+Expected response header:
+value=Fri, 26 Aug 2022 14:38:00 GMT
+
+### Encode_Datetime_ResponseHeader_rfc3339
+
+- Endpoint: `get /encode/datetime/responseheader/rfc3339`
+
+Test rfc3339 encode for datetime header.
+Expected response header:
+value=2022-08-26T18:38:00.000Z
+
+### Encode_Datetime_ResponseHeader_rfc7231
+
+- Endpoint: `get /encode/datetime/responseheader/rfc7231`
+
+Test rfc7231 encode for datetime header.
+Expected response header:
+value=Fri, 26 Aug 2022 14:38:00 GMT
+
+### Encode_Datetime_ResponseHeader_unixTimestamp
+
+- Endpoint: `get /encode/datetime/responseheader/unix-timestamp`
+
+Test unixTimestamp encode for datetime header.
+Expected response header:
+value=1686566864
+
 ### Encode_Duration_Header_default
 
 - Endpoint: `get /encode/duration/header/default`

--- a/packages/cadl-ranch-specs/http/encode/datetime/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/datetime/main.tsp
@@ -301,13 +301,6 @@ model UnixTimestampDatetimeHeader {
   value: utcDateTime;
 }
 
-model UnixTimestampArrayDatetimeHeader {
-  @header({
-    format: "csv",
-  })
-  value: unixTimestampDatetime[];
-}
-
 @operationGroup
 @route("/responseheader")
 namespace ResponseHeader {
@@ -346,13 +339,4 @@ namespace ResponseHeader {
   value=1686566864
   """)
   op unixTimestamp(): NoContentResponse & UnixTimestampDatetimeHeader;
-
-  @route("/unix-timestamp-array")
-  @scenario
-  @scenarioDoc("""
-  Test unixTimestamp encode for datetime array header.
-  Expected response header:
-  value=1686566864,1686734256
-  """)
-  op unixTimestampArray(): NoContentResponse & UnixTimestampArrayDatetimeHeader;
 }

--- a/packages/cadl-ranch-specs/http/encode/datetime/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/datetime/main.tsp
@@ -277,3 +277,82 @@ namespace Header {
     value: unixTimestampDatetime[]
   ): NoContentResponse;
 }
+
+model DefaultDatetimeHeader {
+  @header
+  value: utcDateTime;
+}
+
+model Rfc3339DatetimeHeader {
+  @encode(DateTimeKnownEncoding.rfc3339)
+  @header
+  value: utcDateTime;
+}
+
+model Rfc7231DatetimeHeader {
+  @encode(DateTimeKnownEncoding.rfc7231)
+  @header
+  value: utcDateTime;
+}
+
+model UnixTimestampDatetimeHeader {
+  @encode(DateTimeKnownEncoding.unixTimestamp, int64)
+  @header
+  value: utcDateTime;
+}
+
+model UnixTimestampArrayDatetimeHeader {
+  @header({
+    format: "csv",
+  })
+  value: unixTimestampDatetime[];
+}
+
+@operationGroup
+@route("/responseheader")
+namespace ResponseHeader {
+  @route("/default")
+  @scenario
+  @scenarioDoc("""
+  Test default encode (rfc7231) for datetime header.
+  Expected response header:
+  value=Fri, 26 Aug 2022 14:38:00 GMT
+  """)
+  op default(): NoContentResponse & DefaultDatetimeHeader;
+
+  @route("/rfc3339")
+  @scenario
+  @scenarioDoc("""
+  Test rfc3339 encode for datetime header.
+  Expected response header:
+  value=2022-08-26T18:38:00.000Z
+  """)
+  op rfc3339(): NoContentResponse & Rfc3339DatetimeHeader;
+
+  @route("/rfc7231")
+  @scenario
+  @scenarioDoc("""
+  Test rfc7231 encode for datetime header.
+  Expected response header:
+  value=Fri, 26 Aug 2022 14:38:00 GMT
+  """)
+  op rfc7231(): NoContentResponse & Rfc7231DatetimeHeader;
+
+  @route("/unix-timestamp")
+  @scenario
+  @scenarioDoc("""
+  Test unixTimestamp encode for datetime header.
+  Expected response header:
+  value=1686566864
+  """)
+  op unixTimestamp(): NoContentResponse & UnixTimestampDatetimeHeader;
+
+  @route("/unix-timestamp-array")
+  @scenario
+  @scenarioDoc("""
+  Test unixTimestamp encode for datetime array header.
+  Expected response header:
+  value=1686566864,1686734256
+  """)
+  op unixTimestampArray(): NoContentResponse & UnixTimestampArrayDatetimeHeader;
+}

--- a/packages/cadl-ranch-specs/http/encode/datetime/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/datetime/mockapi.ts
@@ -68,7 +68,7 @@ function createHeaderMockApis(route: string, format: "rfc7231" | "rfc3339" | und
   });
 }
 
-function createResponseHeaderMockApis(route: string, format: "rfc7231" | "rfc3339" | undefined, value: any): MockApi {
+function createResponseHeaderMockApis(route: string, value: any): MockApi {
   const url = `/encode/datetime/responseheader/${route}`;
   return mockapi.get(url, () => {
     return {
@@ -126,18 +126,15 @@ Scenarios.Encode_Datetime_Header_unixTimestampArray = passOnSuccess(
   createHeaderMockApis("unix-timestamp-array", undefined, "1686566864,1686734256"),
 );
 
-Scenarios.Encode_Datetime_Response_Header_default = passOnSuccess(
-  createResponseHeaderMockApis("default", "rfc7231", "Fri, 26 Aug 2022 14:38:00 GMT"),
+Scenarios.Encode_Datetime_ResponseHeader_default = passOnSuccess(
+  createResponseHeaderMockApis("default", "Fri, 26 Aug 2022 14:38:00 GMT"),
 );
-Scenarios.Encode_Datetime_Response_Header_rfc3339 = passOnSuccess(
-  createResponseHeaderMockApis("rfc3339", "rfc3339", "2022-08-26T18:38:00.000Z"),
+Scenarios.Encode_Datetime_ResponseHeader_rfc3339 = passOnSuccess(
+  createResponseHeaderMockApis("rfc3339", "2022-08-26T18:38:00.000Z"),
 );
-Scenarios.Encode_Datetime_Response_Header_rfc7231 = passOnSuccess(
-  createResponseHeaderMockApis("rfc7231", "rfc7231", "Fri, 26 Aug 2022 14:38:00 GMT"),
+Scenarios.Encode_Datetime_ResponseHeader_rfc7231 = passOnSuccess(
+  createResponseHeaderMockApis("rfc7231", "Fri, 26 Aug 2022 14:38:00 GMT"),
 );
-Scenarios.Encode_Datetime_Response_Header_unixTimestamp = passOnSuccess(
-  createResponseHeaderMockApis("unix-timestamp", undefined, "1686566864"),
-);
-Scenarios.Encode_Datetime_Response_Header_unixTimestampArray = passOnSuccess(
-  createResponseHeaderMockApis("unix-timestamp-array", undefined, "1686566864,1686734256"),
+Scenarios.Encode_Datetime_ResponseHeader_unixTimestamp = passOnSuccess(
+  createResponseHeaderMockApis("unix-timestamp", 1686566864),
 );

--- a/packages/cadl-ranch-specs/http/encode/datetime/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/datetime/mockapi.ts
@@ -68,6 +68,16 @@ function createHeaderMockApis(route: string, format: "rfc7231" | "rfc3339" | und
   });
 }
 
+function createResponseHeaderMockApis(route: string, format: "rfc7231" | "rfc3339" | undefined, value: any): MockApi {
+  const url = `/encode/datetime/responseheader/${route}`;
+  return mockapi.get(url, () => {
+    return {
+      status: 204,
+      headers: { value: value },
+    };
+  });
+}
+
 Scenarios.Encode_Datetime_Query_default = passOnSuccess(
   createQueryMockApis("default", "rfc3339", "2022-08-26T18:38:00.000Z"),
 );
@@ -114,4 +124,20 @@ Scenarios.Encode_Datetime_Header_unixTimestamp = passOnSuccess(
 );
 Scenarios.Encode_Datetime_Header_unixTimestampArray = passOnSuccess(
   createHeaderMockApis("unix-timestamp-array", undefined, "1686566864,1686734256"),
+);
+
+Scenarios.Encode_Datetime_Response_Header_default = passOnSuccess(
+  createResponseHeaderMockApis("default", "rfc7231", "Fri, 26 Aug 2022 14:38:00 GMT"),
+);
+Scenarios.Encode_Datetime_Response_Header_rfc3339 = passOnSuccess(
+  createResponseHeaderMockApis("rfc3339", "rfc3339", "2022-08-26T18:38:00.000Z"),
+);
+Scenarios.Encode_Datetime_Response_Header_rfc7231 = passOnSuccess(
+  createResponseHeaderMockApis("rfc7231", "rfc7231", "Fri, 26 Aug 2022 14:38:00 GMT"),
+);
+Scenarios.Encode_Datetime_Response_Header_unixTimestamp = passOnSuccess(
+  createResponseHeaderMockApis("unix-timestamp", undefined, "1686566864"),
+);
+Scenarios.Encode_Datetime_Response_Header_unixTimestampArray = passOnSuccess(
+  createResponseHeaderMockApis("unix-timestamp-array", undefined, "1686566864,1686734256"),
 );


### PR DESCRIPTION
Python meets an [bug](https://github.com/Azure/autorest.python/issues/2083) which is not covered by cadl-ranch