### PR TITLE
[etag] add test case for scenario that only one kind of conditional request header is defined

### DIFF
--- a/.changeset/soft-hats-explode.md
+++ b/.changeset/soft-hats-explode.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+Add test case for scenario that only one conditional request header is defined

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1745,6 +1745,24 @@ Expected header parameters:
   Expected response header:
 - client-request-id=<uuid string same with request header>
 
+### SpecialHeaders_ConditionalRequest_postIfMatch
+
+- Endpoint: `post /special-headers/conditional-request/if-match`
+
+Check when only If-Match in header is defined.
+Expected header parameters:
+
+- if-match="valid"
+
+### SpecialHeaders_ConditionalRequest_postIfNoneMatch
+
+- Endpoint: `post /special-headers/conditional-request/if-none-match`
+
+Check when only If-None-Match in header is defined.
+Expected header parameters:
+
+- if-nonematch="invalid"
+
 ### SpecialHeaders_Repeatability_immediateSuccess
 
 - Endpoint: `post /special-headers/repeatability/immediateSuccess`

--- a/packages/cadl-ranch-specs/http/special-headers/conditional-request/main.tsp
+++ b/packages/cadl-ranch-specs/http/special-headers/conditional-request/main.tsp
@@ -1,0 +1,45 @@
+import "@typespec/http";
+import "@typespec/versioning";
+import "@azure-tools/cadl-ranch-expect";
+
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+@doc("Illustrates conditional request headers")
+@supportedBy("dpg")
+@scenarioService("/special-headers/conditional-request")
+namespace SpecialHeaders.ConditionalRequest;
+
+@scenario
+@doc("""
+Check when only If-Match in header is defined.
+""")
+@scenarioDoc("""
+Check when only If-Match in header is defined.
+Expected header parameters:
+- if-match="valid"
+""")
+@post
+@route("/if-match")
+op postIfMatch(
+  @header("If-Match")
+  @doc("The request should only proceed if an entity matches this string.")
+  ifMatch?: string
+): NoContentResponse;
+
+@scenario
+@doc("""
+Check when only If-None-Match in header is defined.
+""")
+@scenarioDoc("""
+Check when only If-None-Match in header is defined.
+Expected header parameters:
+- if-nonematch="invalid"
+""")
+@post
+@route("/if-none-match")
+op postIfNoneMatch(
+  @header("If-None-Match")
+  @doc("The request should only proceed if no entity matches this string.")
+  ifNoneMatch?: string
+): NoContentResponse;

--- a/packages/cadl-ranch-specs/http/special-headers/conditional-request/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/special-headers/conditional-request/mockapi.ts
@@ -1,0 +1,22 @@
+import { passOnSuccess, mockapi, json, ValidationError, validateValueFormat } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.SpecialHeaders_ConditionalRequest_postIfMatch = passOnSuccess(
+  mockapi.post("/special-headers/conditional-request/if-match", (req) => {
+    req.expect.containsHeader("if-match", '"valid"');
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.SpecialHeaders_ConditionalRequest_postIfNoneMatch = passOnSuccess(
+  mockapi.post("/special-headers/conditional-request/if-none-match", (req) => {
+    req.expect.containsHeader("if-none-match", '"invalid"');
+    return {
+      status: 204,
+    };
+  }),
+);

--- a/packages/cadl-ranch-specs/http/special-headers/conditional-request/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/special-headers/conditional-request/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, mockapi, json, ValidationError, validateValueFormat } from "@azure-tools/cadl-ranch-api";
+import { passOnSuccess, mockapi } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};


### PR DESCRIPTION
some service only define `if-match` header instead of defining both of `if-match` and `if-none-match`.
Related issue https://github.com/Azure/autorest.python/pull/2086