### PR TITLE
Set git config per command instead of globally

### DIFF
--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -8,7 +8,9 @@ const stdout = execSync(`git status --porcelain`).toString();
 if (stdout.trim() !== "") {
   console.log("Commiting the following changes:\n", stdout);
 
-  execSync(`git -c user.email=autochangesetbot@microsoft.com -c user.name="Microsoft Auto Changeset Bot" commit -am "Bump versions"`);
+  execSync(
+    `git -c user.email=autochangesetbot@microsoft.com -c user.name="Microsoft Auto Changeset Bot" commit -am "Bump versions"`,
+  );
   execSync(`git push origin HEAD:${branchName} --force`);
 
   console.log();

--- a/eng/publish.mjs
+++ b/eng/publish.mjs
@@ -2,15 +2,13 @@ import { execSync } from "child_process";
 
 const branchName = "publish/auto-release";
 
-execSync(`git config --global user.email "autochangesetbot@microsoft.com"`);
-execSync(`git config --global user.name "Microsoft Auto Changeset Bot"`);
 execSync(`pnpm changeset version`);
 const stdout = execSync(`git status --porcelain`).toString();
 
 if (stdout.trim() !== "") {
   console.log("Commiting the following changes:\n", stdout);
 
-  execSync(`git commit -am "Bump versions"`);
+  execSync(`git -c user.email=autochangesetbot@microsoft.com -c user.name="Microsoft Auto Changeset Bot" commit -am "Bump versions"`);
   execSync(`git push origin HEAD:${branchName} --force`);
 
   console.log();


### PR DESCRIPTION
- Prevents modifying global state if script run on dev machine
