### PR TITLE
specs, bug fix on bytes request/response body

### DIFF
--- a/.changeset/hungry-laws-retire.md
+++ b/.changeset/hungry-laws-retire.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Bug fix on bytes request/response body

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -929,38 +929,38 @@ value=dGVzdA== (base64 encode of test)
 
 ### Encode_Bytes_RequestBody_base64
 
-- Endpoint: `get /encode/bytes/body/request/base64`
+- Endpoint: `post /encode/bytes/body/request/base64`
 
-Test base64 encode for bytes header.
-Expected header:
-value=dGVzdA== (base64 encode of test)
+Test base64 encode for bytes body.
+Expected body:
+"dGVzdA==" (base64 encode of test, in JSON string)
 
 ### Encode_Bytes_RequestBody_base64url
 
-- Endpoint: `get /encode/bytes/body/request/base64url`
+- Endpoint: `post /encode/bytes/body/request/base64url`
 
-Test base64url encode for bytes header.
-Expected header:
-value=dGVzdA (base64url encode of test)
+Test base64url encode for bytes body.
+Expected body:
+"dGVzdA" (base64url encode of test, in JSON string)
 
 ### Encode_Bytes_RequestBody_customContentType
 
-- Endpoint: `get /encode/bytes/body/request/custom-content-type`
+- Endpoint: `post /encode/bytes/body/request/custom-content-type`
 
 When content type is a custom type(image/png here) and body is `bytes` the payload is a binary file.
 File should match packages/cadl-ranch-specs/assets/image.png
 
 ### Encode_Bytes_RequestBody_default
 
-- Endpoint: `get /encode/bytes/body/request/default`
+- Endpoint: `post /encode/bytes/body/request/default`
 
 Test default encode (base64) for bytes in a json body.
-Expected header:
-value=dGVzdA== (base64 encode of test)
+Expected body:
+"dGVzdA==" (base64 encode of test, in JSON string)
 
 ### Encode_Bytes_RequestBody_octetStream
 
-- Endpoint: `get /encode/bytes/body/request/octet-stream`
+- Endpoint: `post /encode/bytes/body/request/octet-stream`
 
 When content type is application/octet-stream and body is `bytes` the payload is a binary file.
 File should match packages/cadl-ranch-specs/assets/image.png
@@ -969,17 +969,17 @@ File should match packages/cadl-ranch-specs/assets/image.png
 
 - Endpoint: `get /encode/bytes/body/response/base64`
 
-Test base64 encode for bytes header.
-Expected header:
-value=dGVzdA== (base64 encode of test)
+Test base64 encode for bytes body.
+Expected body:
+"dGVzdA==" (base64 encode of test, in JSON string)
 
 ### Encode_Bytes_ResponseBody_base64url
 
 - Endpoint: `get /encode/bytes/body/response/base64url`
 
-Test base64url encode for bytes header.
-Expected header:
-value=dGVzdA (base64url encode of test)
+Test base64url encode for bytes body.
+Expected body:
+"dGVzdA" (base64url encode of test, in JSON string)
 
 ### Encode_Bytes_ResponseBody_customContentType
 
@@ -993,8 +993,8 @@ File should match packages/cadl-ranch-specs/assets/image.png
 - Endpoint: `get /encode/bytes/body/response/default`
 
 Test default encode (base64) for bytes in a json body.
-Expected header:
-value=dGVzdA== (base64 encode of test)
+Expected body:
+"dGVzdA==" (base64 encode of test, in JSON string)
 
 ### Encode_Bytes_ResponseBody_octetStream
 

--- a/packages/cadl-ranch-specs/http/encode/bytes/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/bytes/main.tsp
@@ -234,9 +234,10 @@ namespace RequestBody {
   @scenario
   @scenarioDoc("""
   Test default encode (base64) for bytes in a json body.
-  Expected header:
-  value=dGVzdA== (base64 encode of test)
+  Expected body:
+  "dGVzdA==" (base64 encode of test, in JSON string)
   """)
+  @post
   op default(
     @body
     value: bytes
@@ -248,6 +249,7 @@ namespace RequestBody {
   When content type is application/octet-stream and body is `bytes` the payload is a binary file.
   File should match packages/cadl-ranch-specs/assets/image.png
   """)
+  @post
   op octetStream(
     @header
     contentType: "application/octet-stream",
@@ -262,6 +264,7 @@ namespace RequestBody {
   When content type is a custom type(image/png here) and body is `bytes` the payload is a binary file.
   File should match packages/cadl-ranch-specs/assets/image.png
   """)
+  @post
   op customContentType(
     @header
     contentType: "image/png",
@@ -273,12 +276,13 @@ namespace RequestBody {
   @route("/base64")
   @scenario
   @scenarioDoc("""
-  Test base64 encode for bytes header.
-  Expected header:
-  value=dGVzdA== (base64 encode of test)
+  Test base64 encode for bytes body.
+  Expected body:
+  "dGVzdA==" (base64 encode of test, in JSON string)
   """)
+  @post
   op base64(
-    @header
+    @body
     @encode(BytesKnownEncoding.base64)
     value: bytes
   ): NoContentResponse;
@@ -286,12 +290,13 @@ namespace RequestBody {
   @route("/base64url")
   @scenario
   @scenarioDoc("""
-  Test base64url encode for bytes header.
-  Expected header:
-  value=dGVzdA (base64url encode of test)
+  Test base64url encode for bytes body.
+  Expected body:
+  "dGVzdA" (base64url encode of test, in JSON string)
   """)
+  @post
   op base64url(
-    @header
+    @body
     @encode(BytesKnownEncoding.base64url)
     value: bytes
   ): NoContentResponse;
@@ -304,8 +309,8 @@ namespace ResponseBody {
   @scenario
   @scenarioDoc("""
   Test default encode (base64) for bytes in a json body.
-  Expected header:
-  value=dGVzdA== (base64 encode of test)
+  Expected body:
+  "dGVzdA==" (base64 encode of test, in JSON string)
   """)
   op default(): {
     @body
@@ -343,9 +348,9 @@ namespace ResponseBody {
   @route("/base64")
   @scenario
   @scenarioDoc("""
-  Test base64 encode for bytes header.
-  Expected header:
-  value=dGVzdA== (base64 encode of test)
+  Test base64 encode for bytes body.
+  Expected body:
+  "dGVzdA==" (base64 encode of test, in JSON string)
   """)
   op base64(): {
     @body
@@ -356,9 +361,9 @@ namespace ResponseBody {
   @route("/base64url")
   @scenario
   @scenarioDoc("""
-  Test base64url encode for bytes header.
-  Expected header:
-  value=dGVzdA (base64url encode of test)
+  Test base64url encode for bytes body.
+  Expected body:
+  "dGVzdA" (base64url encode of test, in JSON string)
   """)
   op base64url(): base64urlBytes;
 }

--- a/packages/cadl-ranch-specs/http/encode/bytes/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/bytes/mockapi.ts
@@ -43,7 +43,7 @@ function createHeaderMockApis(route: string, value: any): MockApi {
 
 function createRequestBodyMockApis(route: string, value: any, contentType: string = "application/json"): MockApi {
   const url = `/encode/bytes/body/request/${route}`;
-  return mockapi.get(url, (req) => {
+  return mockapi.post(url, (req) => {
     req.expect.containsHeader("content-type", contentType);
     req.expect.rawBodyEquals(value);
     return {
@@ -85,23 +85,23 @@ Scenarios.Encode_Bytes_Header_base64url = passOnSuccess(createHeaderMockApis("ba
 Scenarios.Encode_Bytes_Header_base64urlArray = passOnSuccess(createHeaderMockApis("base64url-array", "dGVzdA,dGVzdA"));
 
 // Request body
-Scenarios.Encode_Bytes_RequestBody_default = passOnSuccess(createRequestBodyMockApis("default", "dGVzdA=="));
+Scenarios.Encode_Bytes_RequestBody_default = passOnSuccess(createRequestBodyMockApis("default", '"dGVzdA=="'));
 Scenarios.Encode_Bytes_RequestBody_octetStream = passOnSuccess(
   createRequestBodyMockApis("octet-stream", pngFile, "application/octet-stream"),
 );
 Scenarios.Encode_Bytes_RequestBody_customContentType = passOnSuccess(
   createRequestBodyMockApis("custom-content-type", pngFile, "image/png"),
 );
-Scenarios.Encode_Bytes_RequestBody_base64 = passOnSuccess(createRequestBodyMockApis("base64", "dGVzdA=="));
-Scenarios.Encode_Bytes_RequestBody_base64url = passOnSuccess(createRequestBodyMockApis("base64url", "dGVzdA"));
+Scenarios.Encode_Bytes_RequestBody_base64 = passOnSuccess(createRequestBodyMockApis("base64", '"dGVzdA=="'));
+Scenarios.Encode_Bytes_RequestBody_base64url = passOnSuccess(createRequestBodyMockApis("base64url", '"dGVzdA"'));
 
 // Response body
-Scenarios.Encode_Bytes_ResponseBody_default = passOnSuccess(createResponseBodyMockApis("default", "dGVzdA=="));
+Scenarios.Encode_Bytes_ResponseBody_default = passOnSuccess(createResponseBodyMockApis("default", '"dGVzdA=="'));
 Scenarios.Encode_Bytes_ResponseBody_octetStream = passOnSuccess(
   createResponseBodyMockApis("octet-stream", pngFile, "application/octet-stream"),
 );
 Scenarios.Encode_Bytes_ResponseBody_customContentType = passOnSuccess(
   createResponseBodyMockApis("custom-content-type", pngFile, "image/png"),
 );
-Scenarios.Encode_Bytes_ResponseBody_base64 = passOnSuccess(createResponseBodyMockApis("base64", "dGVzdA=="));
-Scenarios.Encode_Bytes_ResponseBody_base64url = passOnSuccess(createResponseBodyMockApis("base64url", "dGVzdA"));
+Scenarios.Encode_Bytes_ResponseBody_base64 = passOnSuccess(createResponseBodyMockApis("base64", '"dGVzdA=="'));
+Scenarios.Encode_Bytes_ResponseBody_base64url = passOnSuccess(createResponseBodyMockApis("base64url", '"dGVzdA"'));


### PR DESCRIPTION
Java emitter is in bad shape around this (we previously kind of assume `@body body: bytes` means stream), so I am not able to test some of the cases). Some is based on observing client log of http request/response.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
