### PR TITLE
use-endpoint-instead-of-localhost

### DIFF
--- a/.changeset/proud-garlics-shake.md
+++ b/.changeset/proud-garlics-shake.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+use-endpoint-instead-of-localhost

--- a/packages/cadl-ranch-specs/http/client/structure/common/service.tsp
+++ b/packages/cadl-ranch-specs/http/client/structure/common/service.tsp
@@ -17,9 +17,13 @@ using Azure.ClientGenerator.Core;
   6. have two clients with a hierarchy relation.
   """)
 @server(
-  "http://localhost:3000/client/structure/{client}",
+  "{endpoint}/client/structure/{client}",
   "",
   {
+    @doc("Need to be set as 'http://localhost:3000' in client.")
+    endpoint: url,
+
+    @doc("Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.")
     client: ClientType,
   }
 )

--- a/packages/cadl-ranch-specs/http/resiliency/srv-driven/main.tsp
+++ b/packages/cadl-ranch-specs/http/resiliency/srv-driven/main.tsp
@@ -25,9 +25,12 @@ using TypeSpec.Http;
 })
 @service
 @server(
-  "http://localhost:3000/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}",
+  "{endpoint}/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}",
   "Testserver endpoint",
   {
+    @doc("Need to be set as 'http://localhost:3000' in client.")
+    endpoint: url,
+
     @doc("Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history. 'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had api-versions 'v1' and 'v2'.")
     serviceDeploymentVersion: string,
 

--- a/packages/cadl-ranch-specs/http/resiliency/srv-driven/old.tsp
+++ b/packages/cadl-ranch-specs/http/resiliency/srv-driven/old.tsp
@@ -16,9 +16,12 @@ using TypeSpec.Versioning;
 })
 @service
 @server(
-  "http://localhost:3000/resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}",
+  "{endpoint}/resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}",
   "Testserver endpoint",
   {
+    @doc("Need to be set as 'http://localhost:3000' in client.")
+    endpoint: url,
+
     @doc("Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history. 'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had api-versions 'v1' and 'v2'.")
     serviceDeploymentVersion: string,
 


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
