### PR TITLE
Special words expansion

### DIFF
--- a/.changeset/nervous-impalas-clap.md
+++ b/.changeset/nervous-impalas-clap.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+Expand the special words scenarios to cover much more words in various location(operation, models, parameters, etc.)

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -66,6 +66,8 @@ words:
   - westus
   - xplat
   - tcgc
+  - elif
+
   # github aliases that show in changlog
   - tadelesh
   - timotheeguerin

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1845,51 +1845,749 @@ Expected header parameters:
 
 Check we recognize Repeatability-Request-ID and Repeatability-First-Sent.
 
-### SpecialWords_Model_get
+### SpecialWords_ModelProperties_sameAsModel
 
-- Endpoint: `get /special-words/model/get`
+- Endpoint: `get /special-words/model-properties/same-as-model`
 
-Expected response body:
+Verify that a property can be called the same as the model name. This can be an issue in some languages where the class name is the constructor.
 
-```json
-{
-  "model.kind": "derived",
-  "derived.name": "my.name",
-  "for": "value"
-}
-```
-
-### SpecialWords_Model_put
-
-- Endpoint: `put /special-words/model/put`
-
-Expected input body:
+Send
 
 ```json
-{
-  "model.kind": "derived",
-  "derived.name": "my.name",
-  "for": "value"
-}
+{ "SameAsModel": "ok" }
 ```
 
-### SpecialWords_Operation_for
+### SpecialWords_Models_and
 
-- Endpoint: `get /special-words/operation/for`
+- Endpoint: `get /special-words/models/and`
 
-A operation name of `for` should work.
+Verify that the name "and" works. Send
 
-### SpecialWords_Parameter_getWithFilter
+```json
+{ "name": "ok" }
+```
 
-- Endpoint: `get /special-words/parameter/filter`
+### SpecialWords_Models_as
 
-Expect input parameter `filter='abc*.'`
+- Endpoint: `get /special-words/models/as`
 
-### SpecialWords_Parameter_getWithIf
+Verify that the name "as" works. Send
 
-- Endpoint: `get /special-words/parameter/if`
+```json
+{ "name": "ok" }
+```
 
-Expect input parameter `if='weekend'`
+### SpecialWords_Models_assert
+
+- Endpoint: `get /special-words/models/assert`
+
+Verify that the name "assert" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_async
+
+- Endpoint: `get /special-words/models/async`
+
+Verify that the name "async" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_await
+
+- Endpoint: `get /special-words/models/await`
+
+Verify that the name "await" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_break
+
+- Endpoint: `get /special-words/models/break`
+
+Verify that the name "break" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_class
+
+- Endpoint: `get /special-words/models/class`
+
+Verify that the name "class" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_constructor
+
+- Endpoint: `get /special-words/models/constructor`
+
+Verify that the name "constructor" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_continue
+
+- Endpoint: `get /special-words/models/continue`
+
+Verify that the name "continue" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_def
+
+- Endpoint: `get /special-words/models/def`
+
+Verify that the name "def" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_del
+
+- Endpoint: `get /special-words/models/del`
+
+Verify that the name "del" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_elif
+
+- Endpoint: `get /special-words/models/elif`
+
+Verify that the name "elif" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_else
+
+- Endpoint: `get /special-words/models/else`
+
+Verify that the name "else" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_except
+
+- Endpoint: `get /special-words/models/except`
+
+Verify that the name "except" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_exec
+
+- Endpoint: `get /special-words/models/exec`
+
+Verify that the name "exec" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_finally
+
+- Endpoint: `get /special-words/models/finally`
+
+Verify that the name "finally" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_for
+
+- Endpoint: `get /special-words/models/for`
+
+Verify that the name "for" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_from
+
+- Endpoint: `get /special-words/models/from`
+
+Verify that the name "from" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_global
+
+- Endpoint: `get /special-words/models/global`
+
+Verify that the name "global" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_if
+
+- Endpoint: `get /special-words/models/if`
+
+Verify that the name "if" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_import
+
+- Endpoint: `get /special-words/models/import`
+
+Verify that the name "import" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_in
+
+- Endpoint: `get /special-words/models/in`
+
+Verify that the name "in" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_is
+
+- Endpoint: `get /special-words/models/is`
+
+Verify that the name "is" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_lambda
+
+- Endpoint: `get /special-words/models/lambda`
+
+Verify that the name "lambda" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_not
+
+- Endpoint: `get /special-words/models/not`
+
+Verify that the name "not" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_or
+
+- Endpoint: `get /special-words/models/or`
+
+Verify that the name "or" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_pass
+
+- Endpoint: `get /special-words/models/pass`
+
+Verify that the name "pass" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_raise
+
+- Endpoint: `get /special-words/models/raise`
+
+Verify that the name "raise" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_return
+
+- Endpoint: `get /special-words/models/return`
+
+Verify that the name "return" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_try
+
+- Endpoint: `get /special-words/models/try`
+
+Verify that the name "try" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_while
+
+- Endpoint: `get /special-words/models/while`
+
+Verify that the name "while" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_with
+
+- Endpoint: `get /special-words/models/with`
+
+Verify that the name "with" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Models_yield
+
+- Endpoint: `get /special-words/models/yield`
+
+Verify that the name "yield" works. Send
+
+```json
+{ "name": "ok" }
+```
+
+### SpecialWords_Operations_and
+
+- Endpoint: `get /special-words/operations/and`
+
+Verify that the name "and" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_as
+
+- Endpoint: `get /special-words/operations/as`
+
+Verify that the name "as" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_assert
+
+- Endpoint: `get /special-words/operations/assert`
+
+Verify that the name "assert" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_async
+
+- Endpoint: `get /special-words/operations/async`
+
+Verify that the name "async" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_await
+
+- Endpoint: `get /special-words/operations/await`
+
+Verify that the name "await" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_break
+
+- Endpoint: `get /special-words/operations/break`
+
+Verify that the name "break" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_class
+
+- Endpoint: `get /special-words/operations/class`
+
+Verify that the name "class" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_constructor
+
+- Endpoint: `get /special-words/operations/constructor`
+
+Verify that the name "constructor" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_continue
+
+- Endpoint: `get /special-words/operations/continue`
+
+Verify that the name "continue" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_def
+
+- Endpoint: `get /special-words/operations/def`
+
+Verify that the name "def" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_del
+
+- Endpoint: `get /special-words/operations/del`
+
+Verify that the name "del" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_elif
+
+- Endpoint: `get /special-words/operations/elif`
+
+Verify that the name "elif" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_else
+
+- Endpoint: `get /special-words/operations/else`
+
+Verify that the name "else" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_except
+
+- Endpoint: `get /special-words/operations/except`
+
+Verify that the name "except" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_exec
+
+- Endpoint: `get /special-words/operations/exec`
+
+Verify that the name "exec" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_finally
+
+- Endpoint: `get /special-words/operations/finally`
+
+Verify that the name "finally" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_for
+
+- Endpoint: `get /special-words/operations/for`
+
+Verify that the name "for" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_from
+
+- Endpoint: `get /special-words/operations/from`
+
+Verify that the name "from" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_global
+
+- Endpoint: `get /special-words/operations/global`
+
+Verify that the name "global" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_if
+
+- Endpoint: `get /special-words/operations/if`
+
+Verify that the name "if" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_import
+
+- Endpoint: `get /special-words/operations/import`
+
+Verify that the name "import" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_in
+
+- Endpoint: `get /special-words/operations/in`
+
+Verify that the name "in" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_is
+
+- Endpoint: `get /special-words/operations/is`
+
+Verify that the name "is" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_lambda
+
+- Endpoint: `get /special-words/operations/lambda`
+
+Verify that the name "lambda" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_not
+
+- Endpoint: `get /special-words/operations/not`
+
+Verify that the name "not" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_or
+
+- Endpoint: `get /special-words/operations/or`
+
+Verify that the name "or" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_pass
+
+- Endpoint: `get /special-words/operations/pass`
+
+Verify that the name "pass" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_raise
+
+- Endpoint: `get /special-words/operations/raise`
+
+Verify that the name "raise" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_return
+
+- Endpoint: `get /special-words/operations/return`
+
+Verify that the name "return" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_try
+
+- Endpoint: `get /special-words/operations/try`
+
+Verify that the name "try" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_while
+
+- Endpoint: `get /special-words/operations/while`
+
+Verify that the name "while" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_with
+
+- Endpoint: `get /special-words/operations/with`
+
+Verify that the name "with" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Operations_yield
+
+- Endpoint: `get /special-words/operations/yield`
+
+Verify that the name "yield" works as an operation name. Call this operation to pass.
+
+### SpecialWords_Parameters_and
+
+- Endpoint: `get /special-words/parameters/and`
+
+Verify that the name "and" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_as
+
+- Endpoint: `get /special-words/parameters/as`
+
+Verify that the name "as" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_assert
+
+- Endpoint: `get /special-words/parameters/assert`
+
+Verify that the name "assert" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_async
+
+- Endpoint: `get /special-words/parameters/async`
+
+Verify that the name "async" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_await
+
+- Endpoint: `get /special-words/parameters/await`
+
+Verify that the name "await" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_break
+
+- Endpoint: `get /special-words/parameters/break`
+
+Verify that the name "break" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_cancellationToken
+
+- Endpoint: `get /special-words/parameters/cancellationToken`
+
+Verify that the name "cancellationToken" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_class
+
+- Endpoint: `get /special-words/parameters/class`
+
+Verify that the name "class" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_constructor
+
+- Endpoint: `get /special-words/parameters/constructor`
+
+Verify that the name "constructor" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_continue
+
+- Endpoint: `get /special-words/parameters/continue`
+
+Verify that the name "continue" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_def
+
+- Endpoint: `get /special-words/parameters/def`
+
+Verify that the name "def" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_del
+
+- Endpoint: `get /special-words/parameters/del`
+
+Verify that the name "del" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_elif
+
+- Endpoint: `get /special-words/parameters/elif`
+
+Verify that the name "elif" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_else
+
+- Endpoint: `get /special-words/parameters/else`
+
+Verify that the name "else" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_except
+
+- Endpoint: `get /special-words/parameters/except`
+
+Verify that the name "except" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_exec
+
+- Endpoint: `get /special-words/parameters/exec`
+
+Verify that the name "exec" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_finally
+
+- Endpoint: `get /special-words/parameters/finally`
+
+Verify that the name "finally" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_for
+
+- Endpoint: `get /special-words/parameters/for`
+
+Verify that the name "for" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_from
+
+- Endpoint: `get /special-words/parameters/from`
+
+Verify that the name "from" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_global
+
+- Endpoint: `get /special-words/parameters/global`
+
+Verify that the name "global" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_if
+
+- Endpoint: `get /special-words/parameters/if`
+
+Verify that the name "if" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_import
+
+- Endpoint: `get /special-words/parameters/import`
+
+Verify that the name "import" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_in
+
+- Endpoint: `get /special-words/parameters/in`
+
+Verify that the name "in" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_is
+
+- Endpoint: `get /special-words/parameters/is`
+
+Verify that the name "is" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_lambda
+
+- Endpoint: `get /special-words/parameters/lambda`
+
+Verify that the name "lambda" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_not
+
+- Endpoint: `get /special-words/parameters/not`
+
+Verify that the name "not" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_or
+
+- Endpoint: `get /special-words/parameters/or`
+
+Verify that the name "or" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_pass
+
+- Endpoint: `get /special-words/parameters/pass`
+
+Verify that the name "pass" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_raise
+
+- Endpoint: `get /special-words/parameters/raise`
+
+Verify that the name "raise" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_return
+
+- Endpoint: `get /special-words/parameters/return`
+
+Verify that the name "return" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_try
+
+- Endpoint: `get /special-words/parameters/try`
+
+Verify that the name "try" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_while
+
+- Endpoint: `get /special-words/parameters/while`
+
+Verify that the name "while" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_with
+
+- Endpoint: `get /special-words/parameters/with`
+
+Verify that the name "with" works. Send this parameter to pass with value `ok`.
+
+### SpecialWords_Parameters_yield
+
+- Endpoint: `get /special-words/parameters/yield`
+
+Verify that the name "yield" works. Send this parameter to pass with value `ok`.
 
 ### Type_Array_BooleanValue_get
 

--- a/packages/cadl-ranch-specs/http/special-words/dec.js
+++ b/packages/cadl-ranch-specs/http/special-words/dec.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+import { $scenario, $scenarioDoc } from "@azure-tools/cadl-ranch-expect";
+import { $route } from "@typespec/http";
+
+export function $opNameScenario(context, target, name) {
+  context.call($scenario, target, name.value);
+  context.call(
+    $scenarioDoc,
+    target,
+    `Verify that the name "${name.value}" works as an operation name. Call this operation to pass.`,
+  );
+  context.call($route, target, `/${name.value}`);
+}
+
+export function $paramNameScenario(context, target, name) {
+  context.call($scenario, target, name.value);
+  context.call(
+    $scenarioDoc,
+    target,
+    `Verify that the name "${name.value}" works. Send this parameter to pass with value \`ok\`.`,
+  );
+  context.call($route, target, `/${name.value}`);
+}
+
+export function $modelNameScenario(context, target, name) {
+  context.call($scenario, target, name.value);
+  context.call(
+    $scenarioDoc,
+    target,
+    `Verify that the name "${name.value}" works. Send\n\`\`\`\json\n{"name": "ok"}\n\`\`\` `,
+  );
+  context.call($route, target, `/${name.value}`);
+}

--- a/packages/cadl-ranch-specs/http/special-words/main.tsp
+++ b/packages/cadl-ranch-specs/http/special-words/main.tsp
@@ -1,84 +1,237 @@
 import "@typespec/http";
 import "@azure-tools/cadl-ranch-expect";
 import "@azure-tools/typespec-client-generator-core";
+import "./dec.js";
 
 using TypeSpec.Http;
 using Azure.ClientGenerator.Core;
 
-@doc("Illustrates operation, parameter and property have name of special words or characters.")
+/**
+ * Scenarios to verify that reserved words can be used in service and generators will handle it appropriately.
+ *
+ * Current list of special words
+ * ```txt
+ * and
+ * as
+ * assert
+ * async
+ * await
+ * break
+ * class
+ * constructor
+ * continue
+ * def
+ * del
+ * elif
+ * else
+ * except
+ * exec
+ * finally
+ * for
+ * from
+ * global
+ * if
+ * import
+ * in
+ * is
+ * lambda
+ * not
+ * or
+ * pass
+ * raise
+ * return
+ * try
+ * while
+ * with
+ * yield
+ * ```
+ */
 @scenarioService("/special-words")
 namespace SpecialWords;
 
-@route("/operation")
-@doc("This interface is for testing operations has a special name.")
+/**
+ * Test reserved words as operation name.
+ */
+@route("/operations")
 @operationGroup
-interface Operation {
-  @scenario
-  @scenarioDoc("A operation name of `for` should work.")
-  @get
-  @route("/for")
-  for(): void;
+interface Operations {
+  @opNameScenario("and") and(): void;
+  @opNameScenario("as") as(): void;
+  @opNameScenario("assert") assert(): void;
+  @opNameScenario("async") async(): void;
+  @opNameScenario("await") await(): void;
+  @opNameScenario("break") break(): void;
+  @opNameScenario("class") class(): void;
+  @opNameScenario("constructor") constructor(): void;
+  @opNameScenario("continue") continue(): void;
+  @opNameScenario("def") def(): void;
+  @opNameScenario("del") del(): void;
+  @opNameScenario("elif") elif(): void;
+  @opNameScenario("else") `else`(): void;
+  @opNameScenario("except") except(): void;
+  @opNameScenario("exec") exec(): void;
+  @opNameScenario("finally") finally(): void;
+  @opNameScenario("for") for(): void;
+  @opNameScenario("from") from(): void;
+  @opNameScenario("global") global(): void;
+  @opNameScenario("if") `if`(): void;
+  @opNameScenario("import") `import`(): void;
+  @opNameScenario("in") in(): void;
+  @opNameScenario("is") `is`(): void;
+  @opNameScenario("lambda") lambda(): void;
+  @opNameScenario("not") not(): void;
+  @opNameScenario("or") or(): void;
+  @opNameScenario("pass") pass(): void;
+  @opNameScenario("raise") raise(): void;
+  @opNameScenario("return") `return`(): void;
+  @opNameScenario("try") try(): void;
+  @opNameScenario("while") while(): void;
+  @opNameScenario("with") with(): void;
+  @opNameScenario("yield") yield(): void;
 }
 
-@route("/parameter")
-@doc("This interface is for testing operations parameters of special words.")
+/**
+ * Verify reserved words as parameter name.
+ */
+@route("/parameters")
 @operationGroup
-interface Parameter {
-  @scenario
-  @scenarioDoc("Expect input parameter `if='weekend'`")
-  @get
-  @route("/if")
-  getWithIf(@header `if`: string): void;
+interface Parameters {
+  @paramNameScenario("and") withAnd(@query and: string): void;
+  @paramNameScenario("as") withAs(@query as: string): void;
+  @paramNameScenario("assert") withAssert(@query assert: string): void;
+  @paramNameScenario("async") withAsync(@query async: string): void;
+  @paramNameScenario("await") withAwait(@query await: string): void;
+  @paramNameScenario("break") withBreak(@query break: string): void;
+  @paramNameScenario("class") withClass(@query class: string): void;
+  @paramNameScenario("constructor") withConstructor(@query constructor: string): void;
+  @paramNameScenario("continue") withContinue(@query continue: string): void;
+  @paramNameScenario("def") withDef(@query def: string): void;
+  @paramNameScenario("del") withDel(@query del: string): void;
+  @paramNameScenario("elif") withElif(@query elif: string): void;
+  @paramNameScenario("else") withElse(@query `else`: string): void;
+  @paramNameScenario("except") withExcept(@query except: string): void;
+  @paramNameScenario("exec") withExec(@query exec: string): void;
+  @paramNameScenario("finally") withFinally(@query finally: string): void;
+  @paramNameScenario("for") withFor(@query for: string): void;
+  @paramNameScenario("from") withFrom(@query from: string): void;
+  @paramNameScenario("global") withGlobal(@query global: string): void;
+  @paramNameScenario("if") withIf(@query `if`: string): void;
+  @paramNameScenario("import") withImport(@query `import`: string): void;
+  @paramNameScenario("in") withIn(@query in: string): void;
+  @paramNameScenario("is") withIs(@query `is`: string): void;
+  @paramNameScenario("lambda") withLambda(@query lambda: string): void;
+  @paramNameScenario("not") withNot(@query not: string): void;
+  @paramNameScenario("or") withOr(@query or: string): void;
+  @paramNameScenario("pass") withPass(@query pass: string): void;
+  @paramNameScenario("raise") withRaise(@query raise: string): void;
+  @paramNameScenario("return") withReturn(@query `return`: string): void;
+  @paramNameScenario("try") withTry(@query try: string): void;
+  @paramNameScenario("while") withWhile(@query while: string): void;
+  @paramNameScenario("with") withWith(@query with: string): void;
+  @paramNameScenario("yield") withYield(@query yield: string): void;
 
-  @scenario
-  @scenarioDoc("Expect input parameter `filter='abc*.'`")
-  @get
-  @route("/filter")
-  getWithFilter(@query filter: string): void;
+  // Non keywords but parameters name that could cause conflict with some language standards
+  @paramNameScenario("cancellationToken") withCancellationToken(@query cancellationToken: string): void;
 }
 
-@doc("This is a base model has discriminator name containing dot.")
-@discriminator("model.kind")
-model BaseModel {}
+/**
+ * Verify model names
+ */
+@route("/models")
+@operationGroup
+namespace Models {
+  model Base {
+    name: string;
+  }
+  model and is Base;
+  model as is Base;
+  model assert is Base;
+  model async is Base;
+  model await is Base;
+  model break is Base;
+  model class is Base;
+  model continue is Base;
+  model constructor is Base;
+  model def is Base;
+  model del is Base;
+  model elif is Base;
+  model `else` is Base;
+  model except is Base;
+  model exec is Base;
+  model finally is Base;
+  model for is Base;
+  model from is Base;
+  model global is Base;
+  model `if` is Base;
+  model `import` is Base;
+  model in is Base;
+  model `is` is Base;
+  model lambda is Base;
+  model not is Base;
+  model or is Base;
+  model pass is Base;
+  model raise is Base;
+  model `return` is Base;
+  model try is Base;
+  model while is Base;
+  model with is Base;
+  model yield is Base;
 
-@doc("This is a model has property names of special words or characters.")
-model DerivedModel extends BaseModel {
-  `model.kind`: "derived";
-  `derived.name`: string;
-  for: string;
+  @modelNameScenario("and") op withAnd(@body body: and): void;
+  @modelNameScenario("as") op withAs(@body body: as): void;
+  @modelNameScenario("assert") op withAssert(@body body: assert): void;
+  @modelNameScenario("async") op withAsync(@body body: async): void;
+  @modelNameScenario("await") op withAwait(@body body: await): void;
+  @modelNameScenario("break") op withBreak(@body body: break): void;
+  @modelNameScenario("class") op withClass(@body body: class): void;
+  @modelNameScenario("constructor") op withConstructor(@body body: constructor): void;
+  @modelNameScenario("continue") op withContinue(@body body: continue): void;
+  @modelNameScenario("def") op withDef(@body body: def): void;
+  @modelNameScenario("del") op withDel(@body body: del): void;
+  @modelNameScenario("elif") op withElif(@body body: elif): void;
+  @modelNameScenario("else") op withElse(@body body: `else`): void;
+  @modelNameScenario("except") op withExcept(@body body: except): void;
+  @modelNameScenario("exec") op withExec(@body body: exec): void;
+  @modelNameScenario("finally") op withFinally(@body body: finally): void;
+  @modelNameScenario("for") op withFor(@body body: for): void;
+  @modelNameScenario("from") op withFrom(@body body: from): void;
+  @modelNameScenario("global") op withGlobal(@body body: global): void;
+  @modelNameScenario("if") op withIf(@body body: `if`): void;
+  @modelNameScenario("import") op withImport(@body body: `import`): void;
+  @modelNameScenario("in") op withIn(@body body: in): void;
+  @modelNameScenario("is") op withIs(@body body: `is`): void;
+  @modelNameScenario("lambda") op withLambda(@body body: lambda): void;
+  @modelNameScenario("not") op withNot(@body body: not): void;
+  @modelNameScenario("or") op withOr(@body body: or): void;
+  @modelNameScenario("pass") op withPass(@body body: pass): void;
+  @modelNameScenario("raise") op withRaise(@body body: raise): void;
+  @modelNameScenario("return") op withReturn(@body body: `return`): void;
+  @modelNameScenario("try") op withTry(@body body: try): void;
+  @modelNameScenario("while") op withWhile(@body body: while): void;
+  @modelNameScenario("with") op withWith(@body body: with): void;
+  @modelNameScenario("yield") op withYield(@body body: yield): void;
 }
 
-@route("/model")
-@doc("This interface is for testing models and properties of special words.")
+/**
+ * Verify model names
+ */
+@route("/model-properties")
 @operationGroup
-interface Model {
+namespace ModelProperties {
+  model SameAsModel {
+    SameAsModel: string;
+  }
+
   @scenario
   @scenarioDoc("""
-  Expected response body:
-  ```json
-  {
-    "model.kind": "derived",
-    "derived.name": "my.name",
-    "for": "value",
-  }
-  ```
-  """)
-  @route("/get")
-  @get
-  get(): BaseModel;
+    Verify that a property can be called the same as the model name. This can be an issue in some languages where the class name is the constructor.
 
-  @scenario
-  @scenarioDoc("""
-  Expected input body:
-  ```json
-    {
-    "model.kind": "derived",
-    "derived.name": "my.name",
-    "for": "value",
-  }
-  ```
-  """)
-  @route("/put")
-  @put
-  put(@body body: BaseModel): void;
+    Send 
+
+    ```json
+    {"SameAsModel": "ok"}
+    ```
+    """)
+  @route("same-as-model")
+  op sameAsModel(@body body: SameAsModel): void;
 }

--- a/packages/cadl-ranch-specs/http/special-words/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/special-words/mockapi.ts
@@ -161,4 +161,4 @@ function propertyNameScenario(route: string, name: string) {
   );
 }
 
-Scenarios.SpecialWords_Models_sameAsModel = propertyNameScenario("same-as-model", "SameAsModel");
+Scenarios.SpecialWords_ModelProperties_sameAsModel = propertyNameScenario("same-as-model", "SameAsModel");

--- a/packages/cadl-ranch-specs/http/special-words/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/special-words/mockapi.ts
@@ -1,61 +1,164 @@
-import { passOnSuccess, ScenarioMockApi, mockapi, json } from "@azure-tools/cadl-ranch-api";
+import { passOnSuccess, ScenarioMockApi, mockapi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.SpecialWords_Operation_for = passOnSuccess(
-  mockapi.get("/special-words/operation/for", (req) => {
-    return {
-      status: 204,
-    };
-  }),
-);
+// ------------------------------------------------------------------------
+// Operation name scenarios
+// ------------------------------------------------------------------------
+function opNameScenario(name: string) {
+  return passOnSuccess(
+    mockapi.get(`/special-words/operation/${name}`, (req) => {
+      return {
+        status: 204,
+      };
+    }),
+  );
+}
 
-Scenarios.SpecialWords_Parameter_getWithIf = passOnSuccess(
-  mockapi.get("/special-words/parameter/if", (req) => {
-    req.expect.containsHeader("if", "weekend");
-    return {
-      status: 204,
-    };
-  }),
-);
-Scenarios.SpecialWords_Parameter_getWithFilter = passOnSuccess(
-  mockapi.get("/special-words/parameter/filter", (req) => {
-    req.expect.containsQueryParam("filter", "abc*.");
-    return {
-      status: 204,
-    };
-  }),
-);
+Scenarios.SpecialWords_Operations_and = opNameScenario("and");
+Scenarios.SpecialWords_Operations_as = opNameScenario("as");
+Scenarios.SpecialWords_Operations_assert = opNameScenario("assert");
+Scenarios.SpecialWords_Operations_async = opNameScenario("async");
+Scenarios.SpecialWords_Operations_await = opNameScenario("await");
+Scenarios.SpecialWords_Operations_break = opNameScenario("break");
+Scenarios.SpecialWords_Operations_class = opNameScenario("class");
+Scenarios.SpecialWords_Operations_constructor = opNameScenario("constructor");
+Scenarios.SpecialWords_Operations_continue = opNameScenario("continue");
+Scenarios.SpecialWords_Operations_def = opNameScenario("def");
+Scenarios.SpecialWords_Operations_del = opNameScenario("del");
+Scenarios.SpecialWords_Operations_elif = opNameScenario("elif");
+Scenarios.SpecialWords_Operations_else = opNameScenario("else");
+Scenarios.SpecialWords_Operations_except = opNameScenario("except");
+Scenarios.SpecialWords_Operations_exec = opNameScenario("exec");
+Scenarios.SpecialWords_Operations_finally = opNameScenario("finally");
+Scenarios.SpecialWords_Operations_for = opNameScenario("for");
+Scenarios.SpecialWords_Operations_from = opNameScenario("from");
+Scenarios.SpecialWords_Operations_global = opNameScenario("global");
+Scenarios.SpecialWords_Operations_if = opNameScenario("if");
+Scenarios.SpecialWords_Operations_import = opNameScenario("import");
+Scenarios.SpecialWords_Operations_in = opNameScenario("in");
+Scenarios.SpecialWords_Operations_is = opNameScenario("is");
+Scenarios.SpecialWords_Operations_lambda = opNameScenario("lambda");
+Scenarios.SpecialWords_Operations_not = opNameScenario("not");
+Scenarios.SpecialWords_Operations_or = opNameScenario("or");
+Scenarios.SpecialWords_Operations_pass = opNameScenario("pass");
+Scenarios.SpecialWords_Operations_raise = opNameScenario("raise");
+Scenarios.SpecialWords_Operations_return = opNameScenario("return");
+Scenarios.SpecialWords_Operations_try = opNameScenario("try");
+Scenarios.SpecialWords_Operations_while = opNameScenario("while");
+Scenarios.SpecialWords_Operations_with = opNameScenario("with");
+Scenarios.SpecialWords_Operations_yield = opNameScenario("yield");
 
-Scenarios.SpecialWords_Model_getContinue = passOnSuccess(
-  mockapi.get("/special-words/model/getContinue", (req) => {
-    return {
-      status: 200,
-      body: json({
-        name: "abc",
-      }),
-    };
-  }),
-);
+// ------------------------------------------------------------------------
+// Parameter name scenarios
+// ------------------------------------------------------------------------
+function paramNameScenario(name: string) {
+  return passOnSuccess(
+    mockapi.get(`/special-words/parameter/${name}`, (req) => {
+      req.expect.containsQueryParam(name, "ok");
+      return {
+        status: 204,
+      };
+    }),
+  );
+}
 
-const modelValue = {
-  "model.kind": "derived",
-  "derived.name": "my.name",
-  "for": "value",
-};
-Scenarios.SpecialWords_Model_get = passOnSuccess(
-  mockapi.get("/special-words/model/get", (req) => {
-    return {
-      status: 200,
-      body: json(modelValue),
-    };
-  }),
-);
-Scenarios.SpecialWords_Model_put = passOnSuccess(
-  mockapi.put("/special-words/model/put", (req) => {
-    req.expect.bodyEquals(modelValue);
-    return {
-      status: 204,
-    };
-  }),
-);
+Scenarios.SpecialWords_Parameters_and = paramNameScenario("and");
+Scenarios.SpecialWords_Parameters_as = paramNameScenario("as");
+Scenarios.SpecialWords_Parameters_assert = paramNameScenario("assert");
+Scenarios.SpecialWords_Parameters_async = paramNameScenario("async");
+Scenarios.SpecialWords_Parameters_await = paramNameScenario("await");
+Scenarios.SpecialWords_Parameters_break = paramNameScenario("break");
+Scenarios.SpecialWords_Parameters_class = paramNameScenario("class");
+Scenarios.SpecialWords_Parameters_constructor = paramNameScenario("constructor");
+Scenarios.SpecialWords_Parameters_continue = paramNameScenario("continue");
+Scenarios.SpecialWords_Parameters_def = paramNameScenario("def");
+Scenarios.SpecialWords_Parameters_del = paramNameScenario("del");
+Scenarios.SpecialWords_Parameters_elif = paramNameScenario("elif");
+Scenarios.SpecialWords_Parameters_else = paramNameScenario("else");
+Scenarios.SpecialWords_Parameters_except = paramNameScenario("except");
+Scenarios.SpecialWords_Parameters_exec = paramNameScenario("exec");
+Scenarios.SpecialWords_Parameters_finally = paramNameScenario("finally");
+Scenarios.SpecialWords_Parameters_for = paramNameScenario("for");
+Scenarios.SpecialWords_Parameters_from = paramNameScenario("from");
+Scenarios.SpecialWords_Parameters_global = paramNameScenario("global");
+Scenarios.SpecialWords_Parameters_if = paramNameScenario("if");
+Scenarios.SpecialWords_Parameters_import = paramNameScenario("import");
+Scenarios.SpecialWords_Parameters_in = paramNameScenario("in");
+Scenarios.SpecialWords_Parameters_is = paramNameScenario("is");
+Scenarios.SpecialWords_Parameters_lambda = paramNameScenario("lambda");
+Scenarios.SpecialWords_Parameters_not = paramNameScenario("not");
+Scenarios.SpecialWords_Parameters_or = paramNameScenario("or");
+Scenarios.SpecialWords_Parameters_pass = paramNameScenario("pass");
+Scenarios.SpecialWords_Parameters_raise = paramNameScenario("raise");
+Scenarios.SpecialWords_Parameters_return = paramNameScenario("return");
+Scenarios.SpecialWords_Parameters_try = paramNameScenario("try");
+Scenarios.SpecialWords_Parameters_while = paramNameScenario("while");
+Scenarios.SpecialWords_Parameters_with = paramNameScenario("with");
+Scenarios.SpecialWords_Parameters_yield = paramNameScenario("yield");
+
+Scenarios.SpecialWords_Parameters_cancellationToken = paramNameScenario("cancellationToken");
+
+// ------------------------------------------------------------------------
+// Model name scenarios
+// ------------------------------------------------------------------------
+function modelNameScenario(name: string) {
+  return passOnSuccess(
+    mockapi.get(`/special-words/model/${name}`, (req) => {
+      req.expect.bodyEquals({ name: "ok" });
+      return {
+        status: 204,
+      };
+    }),
+  );
+}
+
+Scenarios.SpecialWords_Models_and = modelNameScenario("and");
+Scenarios.SpecialWords_Models_as = modelNameScenario("as");
+Scenarios.SpecialWords_Models_assert = modelNameScenario("assert");
+Scenarios.SpecialWords_Models_async = modelNameScenario("async");
+Scenarios.SpecialWords_Models_await = modelNameScenario("await");
+Scenarios.SpecialWords_Models_break = modelNameScenario("break");
+Scenarios.SpecialWords_Models_class = modelNameScenario("class");
+Scenarios.SpecialWords_Models_constructor = modelNameScenario("constructor");
+Scenarios.SpecialWords_Models_continue = modelNameScenario("continue");
+Scenarios.SpecialWords_Models_def = modelNameScenario("def");
+Scenarios.SpecialWords_Models_del = modelNameScenario("del");
+Scenarios.SpecialWords_Models_elif = modelNameScenario("elif");
+Scenarios.SpecialWords_Models_else = modelNameScenario("else");
+Scenarios.SpecialWords_Models_except = modelNameScenario("except");
+Scenarios.SpecialWords_Models_exec = modelNameScenario("exec");
+Scenarios.SpecialWords_Models_finally = modelNameScenario("finally");
+Scenarios.SpecialWords_Models_for = modelNameScenario("for");
+Scenarios.SpecialWords_Models_from = modelNameScenario("from");
+Scenarios.SpecialWords_Models_global = modelNameScenario("global");
+Scenarios.SpecialWords_Models_if = modelNameScenario("if");
+Scenarios.SpecialWords_Models_import = modelNameScenario("import");
+Scenarios.SpecialWords_Models_in = modelNameScenario("in");
+Scenarios.SpecialWords_Models_is = modelNameScenario("is");
+Scenarios.SpecialWords_Models_lambda = modelNameScenario("lambda");
+Scenarios.SpecialWords_Models_not = modelNameScenario("not");
+Scenarios.SpecialWords_Models_or = modelNameScenario("or");
+Scenarios.SpecialWords_Models_pass = modelNameScenario("pass");
+Scenarios.SpecialWords_Models_raise = modelNameScenario("raise");
+Scenarios.SpecialWords_Models_return = modelNameScenario("return");
+Scenarios.SpecialWords_Models_try = modelNameScenario("try");
+Scenarios.SpecialWords_Models_while = modelNameScenario("while");
+Scenarios.SpecialWords_Models_with = modelNameScenario("with");
+Scenarios.SpecialWords_Models_yield = modelNameScenario("yield");
+
+// ------------------------------------------------------------------------
+// Property name scenarios
+// ------------------------------------------------------------------------
+function propertyNameScenario(route: string, name: string) {
+  return passOnSuccess(
+    mockapi.get(`/special-words/model-properties/${route}`, (req) => {
+      req.expect.bodyEquals({ [name]: "ok" });
+      return {
+        status: 204,
+      };
+    }),
+  );
+}
+
+Scenarios.SpecialWords_Models_sameAsModel = propertyNameScenario("same-as-model", "SameAsModel");

--- a/packages/cadl-ranch-specs/tsconfig.json
+++ b/packages/cadl-ranch-specs/tsconfig.json
@@ -5,5 +5,5 @@
     "rootDir": ".",
     "tsBuildInfoFile": "temp/.tsbuildinfo"
   },
-  "include": ["./http/**/*.ts"]
+  "include": ["./http/**/*.ts", "./http/**/*.js"]
 }


### PR DESCRIPTION
Redesign and expansion of the reserved words spec.

Taken the reserved works collection for the python extension. Feel free to add more to the list.

```
and
as
assert
async
await
break
class
constructor
continue
def
del
elif
else
except
exec
finally
for
from
global
if
import
in
is
lambda
not
or
pass
raise
return
try
while
with
yield
```

As well as for parameters:
```
cancellationToken
```


And for model properties

```
[property with same name as model]
````