### PR TITLE
fix(union): add @operationGroup and fix errors

### DIFF
--- a/.changeset/wild-adults-impress.md
+++ b/.changeset/wild-adults-impress.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix(union): add @operationGroup and fix errors

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -5276,7 +5276,7 @@ Expected request to send body:
 Verify a union can be processed in a response:
 
 ```tsp
-Type.Union.Cat | a | 2 | 3.3 | true
+a | 2 | 3.3 | true
 ```
 
 Expected response body:
@@ -5299,7 +5299,7 @@ Expected response body:
 Verify a union can be processed in a response:
 
 ```tsp
-Type.Union.Cat | a | 2 | 3.3 | true
+a | 2 | 3.3 | true
 ```
 
 Expected request to send body:

--- a/packages/cadl-ranch-specs/http/type/union/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/union/main.tsp
@@ -1,7 +1,9 @@
 import "@typespec/http";
 import "@azure-tools/cadl-ranch-expect";
+import "@azure-tools/typespec-client-generator-core";
 
 using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
 
 /**
  * Describe scenarios for various combinations of unions.
@@ -31,12 +33,14 @@ enum UD {
  * Describe union of string "a" | "b" | "c"
  */
 @route("/strings-only")
+@operationGroup
 interface StringsOnly extends GetAndSend<"a" | "b" | "c", "\"b\""> {}
 
 /**
  * Describe union of string string | "b" | "c"
  */
 @route("/string-extensible")
+@operationGroup
 interface StringExtensible extends GetAndSend<string | "b" | "c", "\"custom\""> {}
 
 union StringExtensibleNamedUnion {
@@ -48,24 +52,28 @@ union StringExtensibleNamedUnion {
  * Describe union of string string | "b" | "c" but where the union is named and some of the variants are named
  */
 @route("/string-extensible-named")
+@operationGroup
 interface StringExtensibleNamed extends GetAndSend<StringExtensibleNamedUnion, "\"custom\""> {}
 
 /**
  * Describe union of integer 1 | 2 | 3
  */
 @route("/ints-only")
+@operationGroup
 interface IntsOnly extends GetAndSend<1 | 2 | 3, "2"> {}
 
 /**
  * Describe union of floats 1.1 | 2.2 | 3.3
  */
 @route("/floats-only")
+@operationGroup
 interface FloatsOnly extends GetAndSend<1.1 | 2.2 | 3.3, "2.2"> {}
 
 /**
  * Describe union of models
  */
 @route("/models-only")
+@operationGroup
 interface ModelsOnly extends GetAndSend<Cat | Dog, """
   {
     "name": "test"
@@ -84,6 +92,7 @@ model EnumsOnlyCases {
  * Describe union of 2 different enums
  */
 @route("/enums-only")
+@operationGroup
 interface EnumsOnly extends GetAndSend<LR | UD, """
   {
     "lr": "right",
@@ -93,16 +102,17 @@ interface EnumsOnly extends GetAndSend<LR | UD, """
 
 model StringAndArrayCases {
   /** This should be receive/send the string variant */
-  string: string;
+  string: string | string[];
 
   /** This should be receive/send the array variant */
-  array: string[];
+  array: string | string[];
 }
 
 /**
  * Describe union of a string and an array of strings
  */
 @route("/string-and-array")
+@operationGroup
 interface StringAndArray
   extends GetAndSend<
       string | string[],
@@ -115,7 +125,7 @@ interface StringAndArray
       StringAndArrayCases
     > {}
 
-alias MixedLiteralsUnion = Cat | "a" | 2 | 3.3 | true;
+alias MixedLiteralsUnion = "a" | 2 | 3.3 | true;
 model MixedLiteralsCases {
   /** This should be receive/send the "a" variant */
   stringLiteral: MixedLiteralsUnion;
@@ -134,6 +144,7 @@ model MixedLiteralsCases {
  * Describe union of floats "a" | 2 | 3.3
  */
 @route("/mixed-literals")
+@operationGroup
 interface MixedLiterals
   extends GetAndSend<
       MixedLiteralsUnion,
@@ -167,6 +178,7 @@ model MixedTypesCases {
  * Describe union of floats "a" | 2 | 3.3
  */
 @route("/mixed-types")
+@operationGroup
 interface MixedTypes
   extends GetAndSend<
       MixedTypesUnion,

--- a/packages/cadl-ranch-specs/http/type/union/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/union/mockapi.ts
@@ -56,7 +56,7 @@ const Type_Union_StringAndArray = createGetSendScenario("/type/union/string-and-
 Scenarios.Type_Union_StringAndArray_get = Type_Union_StringAndArray.get;
 Scenarios.Type_Union_StringAndArray_send = Type_Union_StringAndArray.send;
 
-const Type_Union_MixedLiterals = createGetSendScenario("/type/union/mixed-types", {
+const Type_Union_MixedLiterals = createGetSendScenario("/type/union/mixed-literals", {
   stringLiteral: "a",
   intLiteral: 2,
   floatLiteral: 3.3,


### PR DESCRIPTION
1. add `@operationGroup` to interface instances to avoid name conflict
2. fix some errors in union test cases

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
