### PR TITLE
Add tests for payload under different content types and body types

### DIFF
--- a/.changeset/hip-cameras-sing.md
+++ b/.changeset/hip-cameras-sing.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add payload tests for string body and different content types

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1581,10 +1581,10 @@ Scenario that returns a different file encoding depending on the accept header.
 ### Payload_MediaType_StringBody
 
 - Endpoints:
-  - `post /payload/media-type/sendStringAsText`
-  - `post /payload/media-type/getStringAsText`
-  - `post /payload/media-type/sendStringAsJson`
-  - `post /payload/media-type/getStringAsJson`
+  - `post /payload/media-type/sendAsText`
+  - `post /payload/media-type/getAsText`
+  - `post /payload/media-type/sendAsJson`
+  - `post /payload/media-type/getAsJson`
 
 When the request body and response body are both strings, the different media types would lead to different payloads.
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1578,15 +1578,29 @@ Scenario that returns a different file encoding depending on the accept header.
 - image/png return a png image
 - image/jpeg return a jpeg image
 
-### Payload_MediaType_StringBody
+### Payload_MediaType_StringBody_getAsJson
 
-- Endpoints:
-  - `post /payload/media-type/stringBody/sendAsText`
-  - `post /payload/media-type/stringBody/getAsText`
-  - `post /payload/media-type/stringBody/sendAsJson`
-  - `post /payload/media-type/stringBody/getAsJson`
+- Endpoint: `get /payload/media-type/string-body/getAsJson`
 
-When the request body and response body are both strings, the different media types would lead to different payloads.
+Expected response body is "foo".
+
+### Payload_MediaType_StringBody_getAsText
+
+- Endpoint: `get /payload/media-type/string-body/getAsText`
+
+Expected response body is a string '{cat}'.
+
+### Payload_MediaType_StringBody_sendAsJson
+
+- Endpoint: `post /payload/media-type/string-body/sendAsJson`
+
+Expected request body is "foo".
+
+### Payload_MediaType_StringBody_sendAsText
+
+- Endpoint: `post /payload/media-type/string-body/sendAsText`
+
+Expected request body is a string '{cat}'.
 
 ### Payload_MultiPart_FormData_basic
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1581,10 +1581,10 @@ Scenario that returns a different file encoding depending on the accept header.
 ### Payload_MediaType_StringBody
 
 - Endpoints:
-  - `post /payload/media-type/sendAsText`
-  - `post /payload/media-type/getAsText`
-  - `post /payload/media-type/sendAsJson`
-  - `post /payload/media-type/getAsJson`
+  - `post /payload/media-type/stringBody/sendAsText`
+  - `post /payload/media-type/stringBody/getAsText`
+  - `post /payload/media-type/stringBody/sendAsJson`
+  - `post /payload/media-type/stringBody/getAsJson`
 
 When the request body and response body are both strings, the different media types would lead to different payloads.
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1578,6 +1578,16 @@ Scenario that returns a different file encoding depending on the accept header.
 - image/png return a png image
 - image/jpeg return a jpeg image
 
+### Payload_MediaType_StringBody
+
+- Endpoints:
+  - `post /payload/media-type/sendStringAsText`
+  - `post /payload/media-type/getStringAsText`
+  - `post /payload/media-type/sendStringAsJson`
+  - `post /payload/media-type/getStringAsJson`
+
+When the request body and response body are both strings, the different media types would lead to different payloads.
+
 ### Payload_MultiPart_FormData_basic
 
 - Endpoint: `post /multipart/form-data/mixed-parts`

--- a/packages/cadl-ranch-specs/http/payload/content-negotiation/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/content-negotiation/main.tsp
@@ -53,7 +53,7 @@ namespace DifferentBody {
   }
 
   model PngImageAsJson {
-    @header contentType: "image/jpeg";
+    @header contentType: "application/json";
     content: bytes;
   }
 

--- a/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
@@ -20,14 +20,14 @@ namespace Payload.MediaType;
 @route("/stringBody")
 namespace StringBody {
   /**
-   * Expected request body is a string '{"Cat": "Meow"}'.
+   * Expected request body is a string '{cat}'.
    */
   @post
   @route("/sendAsText")
   op sendAsText(@header contentType: "text/plain", @body text: string): OkResponse;
 
   /**
-   * Expected response body is a string '{"Cat": "Meow"}'.
+   * Expected response body is a string '{cat}'.
    */
   @get
   @route("/getAsText")

--- a/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
@@ -12,46 +12,7 @@ using Azure.ClientGenerator.Core;
 @scenarioService("/payload/media-type")
 namespace Payload.MediaType;
 
-@scenario
-@scenarioDoc("""
-  When the request body and response body are both bytes, the different media types would lead to different payloads.
-  """)
-@operationGroup
-namespace BytesBody {
-  @post
-  @route("/sendBytesAsBinary")
-  /**
-   * Expected requsest body is the base64 encoding of "hello", it is "aGVsbG8=" without the quotes.
-   */
-  op sendBytesAsBinary(@header contentType: "application/octet-stream", @body bytes: bytes): OkResponse;
-
-  @get
-  @route("/getBytesAsBinary")
-  /**
-   * Expected response body is the base64 encoding of "hello", it is "aGVsbG8=" without the quotes.
-   */
-  op getBytesAsBinary(): {
-    @header contentType: "application/octet-stream";
-    @body bytes: bytes;
-  };
-
-  @post
-  @route("/sendBytesAsJson")
-  /**
-   * Expected requsest body is the base64 encoding of "hello", it is "aGVsbG8=" with the quotes.
-   */
-  op sendBytesAsJson(@header contentType: "application/json", @body bytes: bytes): OkResponse;
-
-  @get
-  @route("/getBytesAsJson")
-  /**
-   * Expected response body is the base64 encoding of "hello", it is "aGVsbG8=" with the quotes.
-   */
-  op getBytesAsJson(): {
-    @header contentType: "application/json";
-    @body bytes: bytes;
-  };
-}
+// TODO: this file currently only contains string as body, we will add bytes body, model body soon.
 
 @scenario
 @scenarioDoc("""
@@ -59,48 +20,37 @@ namespace BytesBody {
   """)
 @operationGroup
 namespace StringBody {
+  /**
+   * Expected request body is a string '{"Cat": "Meow"}'.
+   */
   @post
   @route("/sendStringAsText")
-  /**
-   * Expected request body is three characters "foo" without the quotes.
-   */
   op sendStringAsText(@header contentType: "text/plain", @body text: string): OkResponse;
 
+  /**
+   * Expected response body is a string '{"Cat": "Meow"}'.
+   */
   @get
   @route("/getStringAsText")
-  /**
-   * Expected response body is three characters "foo" without the quotes.
-   */
   op getStringAsText(): {
     @header contentType: "text/plain";
     @body text: string;
   };
 
+  /**
+   * Expected request body is "foo".
+   */
   @post
   @route("/sendStringAsJson")
-  /**
-   * Expected request body is three characters "foo" with the quotes.
-   */
   op sendStringAsJson(@header contentType: "application/json", @body text: string): OkResponse;
 
+  /**
+   * Expected response body is "foo".
+   */
   @get
   @route("/getStringAsJson")
-  /**
-   * Expected response body is three characters "foo" with the quotes.
-   */
   op getStringAsJson(): {
     @header contentType: "application/json";
     @body text: string;
   };
-
-  // @post
-  // @route("/sendStringAsBinary")
-  // op sendStringAsBinary(@header contentType: "application/octet-stream", @body text: string): OkResponse;
-
-  // @get
-  // @route("/getStringAsBinary")
-  // op getStringAsBinary(): {
-  //   @header contentType: "application/octet-stream";
-  //   @body text: string;
-  // };
 }

--- a/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
@@ -1,0 +1,106 @@
+import "@typespec/http";
+import "@azure-tools/cadl-ranch-expect";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+/**
+ * Test the payload with different media types and different types of the payload itself.
+ */
+@supportedBy("dpg")
+@scenarioService("/payload/media-type")
+namespace Payload.MediaType;
+
+@scenario
+@scenarioDoc("""
+  When the request body and response body are both bytes, the different media types would lead to different payloads.
+  """)
+@operationGroup
+namespace BytesBody {
+  @post
+  @route("/sendBytesAsBinary")
+  /**
+   * Expected requsest body is the base64 encoding of "hello", it is "aGVsbG8=" without the quotes.
+   */
+  op sendBytesAsBinary(@header contentType: "application/octet-stream", @body bytes: bytes): OkResponse;
+
+  @get
+  @route("/getBytesAsBinary")
+  /**
+   * Expected response body is the base64 encoding of "hello", it is "aGVsbG8=" without the quotes.
+   */
+  op getBytesAsBinary(): {
+    @header contentType: "application/octet-stream";
+    @body bytes: bytes;
+  };
+
+  @post
+  @route("/sendBytesAsJson")
+  /**
+   * Expected requsest body is the base64 encoding of "hello", it is "aGVsbG8=" with the quotes.
+   */
+  op sendBytesAsJson(@header contentType: "application/json", @body bytes: bytes): OkResponse;
+
+  @get
+  @route("/getBytesAsJson")
+  /**
+   * Expected response body is the base64 encoding of "hello", it is "aGVsbG8=" with the quotes.
+   */
+  op getBytesAsJson(): {
+    @header contentType: "application/json";
+    @body bytes: bytes;
+  };
+}
+
+@scenario
+@scenarioDoc("""
+  When the request body and response body are both strings, the different media types would lead to different payloads.
+  """)
+@operationGroup
+namespace StringBody {
+  @post
+  @route("/sendStringAsText")
+  /**
+   * Expected request body is three characters "foo" without the quotes.
+   */
+  op sendStringAsText(@header contentType: "text/plain", @body text: string): OkResponse;
+
+  @get
+  @route("/getStringAsText")
+  /**
+   * Expected response body is three characters "foo" without the quotes.
+   */
+  op getStringAsText(): {
+    @header contentType: "text/plain";
+    @body text: string;
+  };
+
+  @post
+  @route("/sendStringAsJson")
+  /**
+   * Expected request body is three characters "foo" with the quotes.
+   */
+  op sendStringAsJson(@header contentType: "application/json", @body text: string): OkResponse;
+
+  @get
+  @route("/getStringAsJson")
+  /**
+   * Expected response body is three characters "foo" with the quotes.
+   */
+  op getStringAsJson(): {
+    @header contentType: "application/json";
+    @body text: string;
+  };
+
+  // @post
+  // @route("/sendStringAsBinary")
+  // op sendStringAsBinary(@header contentType: "application/octet-stream", @body text: string): OkResponse;
+
+  // @get
+  // @route("/getStringAsBinary")
+  // op getStringAsBinary(): {
+  //   @header contentType: "application/octet-stream";
+  //   @body text: string;
+  // };
+}

--- a/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
@@ -12,8 +12,6 @@ using Azure.ClientGenerator.Core;
 @scenarioService("/payload/media-type")
 namespace Payload.MediaType;
 
-// TODO: this file currently only contains string as body, we will add bytes body, model body soon.
-
 @scenario
 @scenarioDoc("""
   When the request body and response body are both strings, the different media types would lead to different payloads.
@@ -24,15 +22,15 @@ namespace StringBody {
    * Expected request body is a string '{"Cat": "Meow"}'.
    */
   @post
-  @route("/sendStringAsText")
-  op sendStringAsText(@header contentType: "text/plain", @body text: string): OkResponse;
+  @route("/sendAsText")
+  op sendAsText(@header contentType: "text/plain", @body text: string): OkResponse;
 
   /**
    * Expected response body is a string '{"Cat": "Meow"}'.
    */
   @get
-  @route("/getStringAsText")
-  op getStringAsText(): {
+  @route("/getAsText")
+  op getAsText(): {
     @header contentType: "text/plain";
     @body text: string;
   };
@@ -41,15 +39,15 @@ namespace StringBody {
    * Expected request body is "foo".
    */
   @post
-  @route("/sendStringAsJson")
-  op sendStringAsJson(@header contentType: "application/json", @body text: string): OkResponse;
+  @route("/sendAsJson")
+  op sendAsJson(@header contentType: "application/json", @body text: string): OkResponse;
 
   /**
    * Expected response body is "foo".
    */
   @get
-  @route("/getStringAsJson")
-  op getStringAsJson(): {
+  @route("/getAsJson")
+  op getAsJson(): {
     @header contentType: "application/json";
     @body text: string;
   };

--- a/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
@@ -17,6 +17,7 @@ namespace Payload.MediaType;
   When the request body and response body are both strings, the different media types would lead to different payloads.
   """)
 @operationGroup
+@route("/stringBody")
 namespace StringBody {
   /**
    * Expected request body is a string '{"Cat": "Meow"}'.

--- a/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
+++ b/packages/cadl-ranch-specs/http/payload/media-type/main.tsp
@@ -12,23 +12,21 @@ using Azure.ClientGenerator.Core;
 @scenarioService("/payload/media-type")
 namespace Payload.MediaType;
 
-@scenario
-@scenarioDoc("""
-  When the request body and response body are both strings, the different media types would lead to different payloads.
-  """)
 @operationGroup
-@route("/stringBody")
+@route("/string-body")
 namespace StringBody {
-  /**
-   * Expected request body is a string '{cat}'.
-   */
+  @scenario
+  @scenarioDoc("""
+  Expected request body is a string '{cat}'.
+  """)
   @post
   @route("/sendAsText")
   op sendAsText(@header contentType: "text/plain", @body text: string): OkResponse;
 
-  /**
-   * Expected response body is a string '{cat}'.
-   */
+  @scenario
+  @scenarioDoc("""
+  Expected response body is a string '{cat}'.
+  """)
   @get
   @route("/getAsText")
   op getAsText(): {
@@ -36,16 +34,18 @@ namespace StringBody {
     @body text: string;
   };
 
-  /**
-   * Expected request body is "foo".
-   */
+  @scenario
+  @scenarioDoc("""
+  Expected request body is "foo".
+  """)
   @post
   @route("/sendAsJson")
   op sendAsJson(@header contentType: "application/json", @body text: string): OkResponse;
 
-  /**
-   * Expected response body is "foo".
-   */
+  @scenario
+  @scenarioDoc("""
+  Expected response body is "foo".
+  """)
   @get
   @route("/getAsJson")
   op getAsJson(): {

--- a/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
@@ -3,41 +3,10 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.Payload_MediaType_BytesBody = passOnSuccess([
-  mockapi.post("/payload/media-type/sendBytesAsBinary", (req) => {
-    req.expect.containsHeader("content-type", "application/octet-stream");
-    req.expect.bodyEquals("aGVsbG8=");
-    return { status: 200 };
-  }),
-
-  mockapi.get("/payload/media-type/getBytesAsBinary", (req) => {
-    req.expect.containsHeader("accept", "application/octet-stream");
-    return { 
-      status: 200,
-      body: {rawContent: "aGVsbG8=", contentType: "application/octet-stream"},
-     };
-  }),
-
-  mockapi.post("/payload/media-type/sendBytesAsJson", (req) => {
-    req.expect.containsHeader("content-type", "application/json");
-    req.expect.bodyEquals('\"aGVsbG8=\"');
-    return { status: 200 };
-  }),
-
-  mockapi.get("/payload/media-type/getBytesAsJson", (req) => {
-    req.expect.containsHeader("accept", "application/json");
-    return {
-      status: 200,
-      body: json("aGVsbG8="),
-      contentType: "application/json",
-    };
-  }),
-]);
-
 Scenarios.Payload_MediaType_StringBody = passOnSuccess([
   mockapi.post("/payload/media-type/sendStringAsText", (req) => {
     req.expect.containsHeader("content-type", "text/plain");
-    req.expect.bodyEquals("foo");
+    req.expect.bodyEquals('{"Cat": "Meow"}');
     return { status: 200 };
   }),
 
@@ -45,13 +14,13 @@ Scenarios.Payload_MediaType_StringBody = passOnSuccess([
     req.expect.containsHeader("accept", "text/plain");
     return {
       status: 200,
-      body: {rawContent: "foo", contentType: "text/plain"},
+      body: { rawContent: '{"Cat": "Meow"}', contentType: "text/plain" },
     };
   }),
 
   mockapi.post("/payload/media-type/sendStringAsJson", (req) => {
     req.expect.containsHeader("content-type", "application/json");
-    req.expect.bodyEquals('\"foo\"');
+    req.expect.bodyEquals("foo");
     return { status: 200 };
   }),
 

--- a/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
@@ -4,13 +4,13 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Payload_MediaType_StringBody = passOnSuccess([
-  mockapi.post("/payload/media-type/sendStringAsText", (req) => {
+  mockapi.post("/payload/media-type/sendAsText", (req) => {
     req.expect.containsHeader("content-type", "text/plain");
     req.expect.bodyEquals('{"Cat": "Meow"}');
     return { status: 200 };
   }),
 
-  mockapi.get("/payload/media-type/getStringAsText", (req) => {
+  mockapi.get("/payload/media-type/getAsText", (req) => {
     req.expect.containsHeader("accept", "text/plain");
     return {
       status: 200,
@@ -18,13 +18,13 @@ Scenarios.Payload_MediaType_StringBody = passOnSuccess([
     };
   }),
 
-  mockapi.post("/payload/media-type/sendStringAsJson", (req) => {
+  mockapi.post("/payload/media-type/sendAsJson", (req) => {
     req.expect.containsHeader("content-type", "application/json");
     req.expect.bodyEquals("foo");
     return { status: 200 };
   }),
 
-  mockapi.get("/payload/media-type/getStringAsJson", (req) => {
+  mockapi.get("/payload/media-type/getAsJson", (req) => {
     req.expect.containsHeader("accept", "application/json");
     return {
       status: 200,

--- a/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
@@ -1,0 +1,66 @@
+import { json, mockapi, passOnSuccess } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Payload_MediaType_BytesBody = passOnSuccess([
+  mockapi.post("/payload/media-type/sendBytesAsBinary", (req) => {
+    req.expect.containsHeader("content-type", "application/octet-stream");
+    req.expect.bodyEquals("aGVsbG8=");
+    return { status: 200 };
+  }),
+
+  mockapi.get("/payload/media-type/getBytesAsBinary", (req) => {
+    req.expect.containsHeader("accept", "application/octet-stream");
+    return { 
+      status: 200,
+      body: {rawContent: "aGVsbG8=", contentType: "application/octet-stream"},
+     };
+  }),
+
+  mockapi.post("/payload/media-type/sendBytesAsJson", (req) => {
+    req.expect.containsHeader("content-type", "application/json");
+    req.expect.bodyEquals('\"aGVsbG8=\"');
+    return { status: 200 };
+  }),
+
+  mockapi.get("/payload/media-type/getBytesAsJson", (req) => {
+    req.expect.containsHeader("accept", "application/json");
+    return {
+      status: 200,
+      body: json("aGVsbG8="),
+      contentType: "application/json",
+    };
+  }),
+]);
+
+Scenarios.Payload_MediaType_StringBody = passOnSuccess([
+  mockapi.post("/payload/media-type/sendStringAsText", (req) => {
+    req.expect.containsHeader("content-type", "text/plain");
+    req.expect.bodyEquals("foo");
+    return { status: 200 };
+  }),
+
+  mockapi.get("/payload/media-type/getStringAsText", (req) => {
+    req.expect.containsHeader("accept", "text/plain");
+    return {
+      status: 200,
+      body: {rawContent: "foo", contentType: "text/plain"},
+    };
+  }),
+
+  mockapi.post("/payload/media-type/sendStringAsJson", (req) => {
+    req.expect.containsHeader("content-type", "application/json");
+    req.expect.bodyEquals('\"foo\"');
+    return { status: 200 };
+  }),
+
+  mockapi.get("/payload/media-type/getStringAsJson", (req) => {
+    req.expect.containsHeader("accept", "application/json");
+    return {
+      status: 200,
+      body: json("foo"),
+      contentType: "application/json",
+    };
+  }),
+]);

--- a/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
@@ -6,7 +6,7 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 Scenarios.Payload_MediaType_StringBody = passOnSuccess([
   mockapi.post("/payload/media-type/stringBody/sendAsText", (req) => {
     req.expect.containsHeader("content-type", "text/plain");
-    req.expect.bodyEquals('{"Cat": "Meow"}');
+    req.expect.bodyEquals("{cat}");
     return { status: 200 };
   }),
 
@@ -14,7 +14,7 @@ Scenarios.Payload_MediaType_StringBody = passOnSuccess([
     req.expect.containsHeader("accept", "text/plain");
     return {
       status: 200,
-      body: { rawContent: '{"Cat": "Meow"}', contentType: "text/plain" },
+      body: { rawContent: "{cat}", contentType: "text/plain" },
     };
   }),
 

--- a/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
@@ -4,13 +4,13 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Payload_MediaType_StringBody = passOnSuccess([
-  mockapi.post("/payload/media-type/sendAsText", (req) => {
+  mockapi.post("/payload/media-type/stringBody/sendAsText", (req) => {
     req.expect.containsHeader("content-type", "text/plain");
     req.expect.bodyEquals('{"Cat": "Meow"}');
     return { status: 200 };
   }),
 
-  mockapi.get("/payload/media-type/getAsText", (req) => {
+  mockapi.get("/payload/media-type/stringBody/getAsText", (req) => {
     req.expect.containsHeader("accept", "text/plain");
     return {
       status: 200,
@@ -18,13 +18,13 @@ Scenarios.Payload_MediaType_StringBody = passOnSuccess([
     };
   }),
 
-  mockapi.post("/payload/media-type/sendAsJson", (req) => {
+  mockapi.post("/payload/media-type/stringBody/sendAsJson", (req) => {
     req.expect.containsHeader("content-type", "application/json");
     req.expect.bodyEquals("foo");
     return { status: 200 };
   }),
 
-  mockapi.get("/payload/media-type/getAsJson", (req) => {
+  mockapi.get("/payload/media-type/stringBody/getAsJson", (req) => {
     req.expect.containsHeader("accept", "application/json");
     return {
       status: 200,

--- a/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/payload/media-type/mockapi.ts
@@ -3,28 +3,34 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.Payload_MediaType_StringBody = passOnSuccess([
-  mockapi.post("/payload/media-type/stringBody/sendAsText", (req) => {
+Scenarios.Payload_MediaType_StringBody_sendAsText = passOnSuccess(
+  mockapi.post("/payload/media-type/string-body/sendAsText", (req) => {
     req.expect.containsHeader("content-type", "text/plain");
     req.expect.bodyEquals("{cat}");
     return { status: 200 };
   }),
+);
 
-  mockapi.get("/payload/media-type/stringBody/getAsText", (req) => {
+Scenarios.Payload_MediaType_StringBody_getAsText = passOnSuccess(
+  mockapi.get("/payload/media-type/string-body/getAsText", (req) => {
     req.expect.containsHeader("accept", "text/plain");
     return {
       status: 200,
       body: { rawContent: "{cat}", contentType: "text/plain" },
     };
   }),
+);
 
-  mockapi.post("/payload/media-type/stringBody/sendAsJson", (req) => {
+Scenarios.Payload_MediaType_StringBody_sendAsJson = passOnSuccess(
+  mockapi.post("/payload/media-type/string-body/sendAsJson", (req) => {
     req.expect.containsHeader("content-type", "application/json");
     req.expect.bodyEquals("foo");
     return { status: 200 };
   }),
+);
 
-  mockapi.get("/payload/media-type/stringBody/getAsJson", (req) => {
+Scenarios.Payload_MediaType_StringBody_getAsJson = passOnSuccess(
+  mockapi.get("/payload/media-type/string-body/getAsJson", (req) => {
     req.expect.containsHeader("accept", "application/json");
     return {
       status: 200,
@@ -32,4 +38,4 @@ Scenarios.Payload_MediaType_StringBody = passOnSuccess([
       contentType: "application/json",
     };
   }),
-]);
+);


### PR DESCRIPTION
1. Add tests for payload under different content types and body types
2. Fix a bug in packages\cadl-ranch-specs\http\payload\content-negotiation

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
