### PR TITLE
[DO NOT REVIEW]Add test cases for decimal to cover encode string and corner cases

### DIFF
--- a/.changeset/tender-ears-exercise.md
+++ b/.changeset/tender-ears-exercise.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add decimal cases to cover encode string and corner cases

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -5393,6 +5393,60 @@ Expected input body:
 0.3
 ```
 
+### Type_Scalar_DecimalBigIntType_requestBody
+
+- Endpoint: `put /type/scalar/decimal/big_int/resquest_body`
+
+Expected input body:
+
+```json
+9223372036854775807
+```
+
+### Type_Scalar_DecimalBigIntType_requestParameter
+
+- Endpoint: `get /type/scalar/decimal/big_int/request_parameter`
+
+Expected request parameter:
+value=9223372036854775807
+
+### Type_Scalar_DecimalBigIntType_responseBody
+
+- Endpoint: `get /type/scalar/decimal/big_int/response_body`
+
+Expected response body:
+
+```json
+9223372036854775807
+```
+
+### Type_Scalar_DecimalHighPrecisionFractionType_requestBody
+
+- Endpoint: `put /type/scalar/decimal/high_precision_fraction/resquest_body`
+
+Expected input body:
+
+```json
+0.14285714285714285714285714285714
+```
+
+### Type_Scalar_DecimalHighPrecisionFractionType_requestParameter
+
+- Endpoint: `get /type/scalar/decimal/high_precision_fraction/request_parameter`
+
+Expected request parameter:
+value=0.14285714285714285714285714285714
+
+### Type_Scalar_DecimalHighPrecisionFractionType_responseBody
+
+- Endpoint: `get /type/scalar/decimal/high_precision_fraction/response_body`
+
+Expected response body:
+
+```json
+0.14285714285714285714285714285714
+```
+
 ### Type_Scalar_DecimalType_requestBody
 
 - Endpoint: `put /type/scalar/decimal/resquest_body`

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1212,6 +1212,69 @@ Test unixTimestamp encode for datetime header.
 Expected response header:
 value=1686566864
 
+### Encode_Decimal_Property_default
+
+- Endpoint: `post /encode/decimal/property/default`
+
+Test operation with request and response model contains a decimal property with default encode.
+Expected request body:
+
+```json
+{
+  "value": 0.6666
+}
+```
+
+Expected response body:
+
+```json
+{
+  "value": 0.6666
+}
+```
+
+### Encode_Decimal_Property_string
+
+- Endpoint: `post /encode/decimal/property/string`
+
+Test operation with request and response model contains a decimal property with default encode.
+Expected request body:
+
+```json
+{
+  "value": "0.6666"
+}
+```
+
+Expected response body:
+
+```json
+{
+  "value": "0.6666"
+}
+```
+
+### Encode_Decimal_Property_stringDecimalArray
+
+- Endpoint: `get /encode/decimal/property/string-decimal-array`
+
+Test operation with request and response model contains an array property which elements are decimal with string encode.
+Expected request body:
+
+```json
+{
+  "value": ["0.6666", "0.3333"]
+}
+```
+
+Expected response body:
+
+```json
+{
+  "value": ["0.6666", "0.3333"]
+}
+```
+
 ### Encode_Duration_Header_default
 
 - Endpoint: `get /encode/duration/header/default`

--- a/packages/cadl-ranch-specs/http/encode/decimal/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/decimal/main.tsp
@@ -1,0 +1,91 @@
+import "@typespec/http";
+import "@azure-tools/cadl-ranch-expect";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@doc("Test for encode decorator on decimal.")
+@supportedBy("dpg")
+@scenarioService("/encode/decimal")
+namespace Encode.Decimal;
+
+@operationGroup
+@route("/property")
+namespace Property {
+  model DefaultDecimalProperty {
+    value: decimal;
+  }
+
+  model StringDecimalProperty {
+    @encode("string")
+    value: decimal;
+  }
+
+  @encode("string")
+  scalar StringDecimal extends decimal;
+
+  model StringDecimalArrayProperty {
+    value: StringDecimal[];
+  }
+
+  @route("/default")
+  @scenario
+  @scenarioDoc("""
+  Test operation with request and response model contains a decimal property with default encode.
+  Expected request body:
+  ```json
+  {
+    "value": 0.6666
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "value": 0.6666
+  }
+  ```
+  """)
+  @post
+  op default(@body body: DefaultDecimalProperty): DefaultDecimalProperty;
+
+  @route("/string")
+  @scenario
+  @scenarioDoc("""
+  Test operation with request and response model contains a decimal property with default encode.
+  Expected request body:
+  ```json
+  {
+    "value": "0.6666"
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "value": "0.6666"
+  }
+  ```
+  """)
+  @post
+  op string(@body body: StringDecimalProperty): StringDecimalProperty;
+
+ 
+  @route("/string-decimal-array")
+  @scenario
+  @scenarioDoc("""
+  Test operation with request and response model contains an array property which elements are decimal with string encode.
+  Expected request body:
+  ```json
+  {
+    "value": ["0.6666", "0.3333"]
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "value": ["0.6666", "0.3333"]
+  }
+  ```
+  """)
+  op stringDecimalArray(@body body: StringDecimalArrayProperty): StringDecimalArrayProperty;
+}

--- a/packages/cadl-ranch-specs/http/encode/decimal/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/decimal/main.tsp
@@ -69,7 +69,6 @@ namespace Property {
   @post
   op string(@body body: StringDecimalProperty): StringDecimalProperty;
 
- 
   @route("/string-decimal-array")
   @scenario
   @scenarioDoc("""

--- a/packages/cadl-ranch-specs/http/encode/decimal/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/decimal/mockapi.ts
@@ -1,0 +1,22 @@
+
+import { passOnSuccess, mockapi, json, MockApi } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function createPropertyMockApis(route: string, value: any): MockApi {
+    const url = `/encode/decimal/property/${route}`;
+    return mockapi.post(url, (req) => {
+        req.expect.coercedBodyEquals({ value: value });
+        return {
+            status: 200,
+            body: json({ value: value }),
+        };
+    });
+}
+
+Scenarios.Encode_Decimal_Property_default = passOnSuccess(createPropertyMockApis("default", 0.6666));
+Scenarios.Encode_Decimal_Property_string = passOnSuccess(createPropertyMockApis("string", "0.6666"));
+Scenarios.Encode_Decimal_Property_stringDecimalArray = passOnSuccess(
+    createPropertyMockApis("string-decimal-array", ["0.6666", "0.3333"]),
+);

--- a/packages/cadl-ranch-specs/http/encode/decimal/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/decimal/mockapi.ts
@@ -1,22 +1,21 @@
-
 import { passOnSuccess, mockapi, json, MockApi } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 function createPropertyMockApis(route: string, value: any): MockApi {
-    const url = `/encode/decimal/property/${route}`;
-    return mockapi.post(url, (req) => {
-        req.expect.coercedBodyEquals({ value: value });
-        return {
-            status: 200,
-            body: json({ value: value }),
-        };
-    });
+  const url = `/encode/decimal/property/${route}`;
+  return mockapi.post(url, (req) => {
+    req.expect.coercedBodyEquals({ value: value });
+    return {
+      status: 200,
+      body: json({ value: value }),
+    };
+  });
 }
 
 Scenarios.Encode_Decimal_Property_default = passOnSuccess(createPropertyMockApis("default", 0.6666));
 Scenarios.Encode_Decimal_Property_string = passOnSuccess(createPropertyMockApis("string", "0.6666"));
 Scenarios.Encode_Decimal_Property_stringDecimalArray = passOnSuccess(
-    createPropertyMockApis("string-decimal-array", ["0.6666", "0.3333"]),
+  createPropertyMockApis("string-decimal-array", ["0.6666", "0.3333"]),
 );

--- a/packages/cadl-ranch-specs/http/type/scalar/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/scalar/main.tsp
@@ -116,6 +116,17 @@ interface ScalarTypesOperations<T, TDoc extends string> {
 @operationGroup
 interface DecimalType extends ScalarTypesOperations<decimal, "0.33333"> {}
 
+@doc("Decimal type for big int")
+@route("/decimal/big_int")
+@operationGroup
+interface DecimalBigIntType extends ScalarTypesOperations<decimal, "9223372036854775807"> {}
+
+@doc("Decimal type for high precision fraction")
+@route("/decimal/high_precision_fraction")
+@operationGroup
+interface DecimalHighPrecisionFractionType
+  extends ScalarTypesOperations<decimal, "0.14285714285714285714285714285714"> {}
+
 @doc("Decimal128 type")
 @route("/decimal128")
 @operationGroup

--- a/packages/cadl-ranch-specs/http/type/scalar/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/scalar/mockapi.ts
@@ -84,6 +84,51 @@ Scenarios.Type_Scalar_Decimal128Type_responseBody = passOnSuccess(Decimal128Type
 Scenarios.Type_Scalar_Decimal128Type_requestBody = passOnSuccess(Decimal128TypeMock.requestBody);
 Scenarios.Type_Scalar_Decimal128Type_requestParameter = passOnSuccess(Decimal128TypeMock.requestParameter);
 
+function createModelMockApisWithRawContent(route: string, value: any): MockApiOperations {
+  return {
+    responseBody: mockapi.get(`/type/scalar/${route}/response_body`, (req) => {
+      return {
+        status: 200,
+        body: {
+          contentType: "application/json",
+          rawContent: value,
+        },
+      };
+    }),
+    requestBody: mockapi.put(`/type/scalar/${route}/resquest_body`, (req) => {
+      req.expect.rawBodyEquals(value);
+      return {
+        status: 204,
+      };
+    }),
+    requestParameter: mockapi.get(`/type/scalar/${route}/request_parameter`, (req) => {
+      req.expect.containsQueryParam("value", value);
+      return {
+        status: 204,
+      };
+    }),
+  };
+}
+
+const DecimalBigIntTypeMock = createModelMockApisWithRawContent("decimal/big_int", "9223372036854775807");
+Scenarios.Type_Scalar_DecimalBigIntType_responseBody = passOnSuccess(DecimalBigIntTypeMock.responseBody);
+Scenarios.Type_Scalar_DecimalBigIntType_requestBody = passOnSuccess(DecimalBigIntTypeMock.requestBody);
+Scenarios.Type_Scalar_DecimalBigIntType_requestParameter = passOnSuccess(DecimalBigIntTypeMock.requestParameter);
+
+const DecimalHighPrecisionFractionTypeMock = createModelMockApisWithRawContent(
+  "decimal/high_precision_fraction",
+  "0.14285714285714285714285714285714",
+);
+Scenarios.Type_Scalar_DecimalHighPrecisionFractionType_responseBody = passOnSuccess(
+  DecimalHighPrecisionFractionTypeMock.responseBody,
+);
+Scenarios.Type_Scalar_DecimalHighPrecisionFractionType_requestBody = passOnSuccess(
+  DecimalHighPrecisionFractionTypeMock.requestBody,
+);
+Scenarios.Type_Scalar_DecimalHighPrecisionFractionType_requestParameter = passOnSuccess(
+  DecimalHighPrecisionFractionTypeMock.requestParameter,
+);
+
 interface NumberTypesVerifyOperations {
   prepareVerify: MockApi;
   verify: MockApi;


### PR DESCRIPTION
this is from JS discussion https://github.com/Azure/autorest.typescript/issues/2157#issuecomment-1846052801 and pending https://github.com/microsoft/typespec/issues/2762.

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
