### PR TITLE
add some new cases to type/property/additional-properties for the scenarios that the model with additional properties are extended

### DIFF
--- a/.changeset/nervous-carrots-beg.md
+++ b/.changeset/nervous-carrots-beg.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+Add a few new cases to type/property/additional-properties to cover the case when a model with additional properties is derived by other models

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "search.exclude": {
     "**/node_modules": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": true
   },
   "search.exclude": {
     "**/node_modules": true,

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -3869,7 +3869,7 @@ Expected response body:
   "name": "ExtendsUnknownAdditionalProperties",
   "index": 314,
   "age": 2.71828,
-  "prop1": 42,
+  "prop1": 32,
   "prop2": true,
   "prop3": "abc"
 }
@@ -3886,7 +3886,43 @@ Expected input body:
   "name": "ExtendsUnknownAdditionalProperties",
   "index": 314,
   "age": 2.71828,
-  "prop1": 42,
+  "prop1": 32,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
+### Type_Property_AdditionalProperties_ExtendsUnknownDiscriminated_get
+
+- Endpoint: `get /type/property/additionalProperties/extendsUnknownDiscriminated`
+
+Expected response body:
+
+```json
+{
+  "kind": "derived",
+  "name": "Derived",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 32,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
+### Type_Property_AdditionalProperties_ExtendsUnknownDiscriminated_put
+
+- Endpoint: `put /type/property/additionalProperties/extendsUnknownDiscriminated`
+
+Expected input body:
+
+```json
+{
+  "kind": "derived",
+  "name": "Derived",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 32,
   "prop2": true,
   "prop3": "abc"
 }
@@ -3996,6 +4032,40 @@ Expected input body:
 ```json
 {
   "name": "IsUnknownAdditionalProperties",
+  "prop1": 32,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
+### Type_Property_AdditionalProperties_IsUnknownDerived_get
+
+- Endpoint: `get /type/property/additionalProperties/isRecordUnknownDerived`
+
+Expected response body:
+
+```json
+{
+  "name": "IsUnknownAdditionalProperties",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 32,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
+### Type_Property_AdditionalProperties_IsUnknownDerived_put
+
+- Endpoint: `put /type/property/additionalProperties/isRecordUnknownDerived`
+
+Expected input body:
+
+```json
+{
+  "name": "IsUnknownAdditionalProperties",
+  "index": 314,
+  "age": 2.71828,
   "prop1": 32,
   "prop2": true,
   "prop3": "abc"

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -4072,6 +4072,42 @@ Expected input body:
 }
 ```
 
+### Type_Property_AdditionalProperties_IsUnknownDiscriminated_get
+
+- Endpoint: `get /type/property/additionalProperties/isUnknownDiscriminated`
+
+Expected response body:
+
+```json
+{
+  "kind": "derived",
+  "name": "Derived",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 32,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
+### Type_Property_AdditionalProperties_IsUnknownDiscriminated_put
+
+- Endpoint: `put /type/property/additionalProperties/isUnknownDiscriminated`
+
+Expected input body:
+
+```json
+{
+  "kind": "derived",
+  "name": "Derived",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 32,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
 ### Type_Property_Nullable_Bytes_getNonNull
 
 - Endpoint: `get /type/property/nullable/bytes/non-null`

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -3858,6 +3858,40 @@ Expected input body:
 }
 ```
 
+### Type_Property_AdditionalProperties_ExtendsUnknownDerived_get
+
+- Endpoint: `get /type/property/additionalProperties/extendsRecordUnknownDerived`
+
+Expected response body:
+
+```json
+{
+  "name": "ExtendsUnknownAdditionalProperties",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 42,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
+### Type_Property_AdditionalProperties_ExtendsUnknownDerived_put
+
+- Endpoint: `put /type/property/additionalProperties/extendsRecordUnknownDerived`
+
+Expected input body:
+
+```json
+{
+  "name": "ExtendsUnknownAdditionalProperties",
+  "index": 314,
+  "age": 2.71828,
+  "prop1": 42,
+  "prop2": true,
+  "prop3": "abc"
+}
+```
+
 ### Type_Property_AdditionalProperties_IsFloat_get
 
 - Endpoint: `get /type/property/additionalProperties/isRecordFloat`

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
@@ -64,6 +64,7 @@ interface ExtendsUnknown
       "{'name': 'ExtendsUnknownAdditionalProperties', 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
+@doc("The model extends from a type that extends from Record<unknown>.")
 model ExtendsUnknownAdditionalPropertiesDerived extends ExtendsUnknownAdditionalProperties {
   @doc("The index property")
   index: int32;
@@ -93,6 +94,23 @@ interface IsUnknown
   extends ModelOperations<
       IsUnknownAdditionalProperties,
       "{'name': 'IsUnknownAdditionalProperties', 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
+    > {}
+
+@doc("The model extends from a type that is Record<unknown> type")
+model IsUnknownAdditionalPropertiesDerived extends IsUnknownAdditionalProperties {
+  @doc("The index property")
+  index: int32;
+
+  @doc("The age property")
+  age?: float32;
+}
+
+@route("/isRecordUnknownDerived")
+@operationGroup
+interface IsUnknownDerived
+  extends ModelOperations<
+      IsUnknownAdditionalPropertiesDerived,
+      "{'name': 'IsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 42, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
 // ********************************************** Record<string> **********************************************

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
@@ -81,6 +81,35 @@ interface ExtendsUnknownDerived
       "{'name': 'ExtendsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
+@doc("The model extends from Record<unknown> with a discriminator.")
+@discriminator("kind")
+model ExtendsUnknownAdditionalPropertiesDiscriminated extends Record<unknown> {
+  @doc("The name property")
+  name: string;
+
+  @doc("The discriminator")
+  kind: string;
+}
+
+@doc("The derived discriminated type")
+model ExtendsUnknownAdditionalPropertiesDiscriminatedDerived extends ExtendsUnknownAdditionalPropertiesDiscriminated {
+  kind: "derived";
+
+  @doc("The index property")
+  index: int32;
+
+  @doc("The age property")
+  age?: float32;
+}
+
+@route("/extendsUnknownDiscriminated")
+@operationGroup
+interface ExtendsUnknownDiscriminated
+  extends ModelOperations<
+      ExtendsUnknownAdditionalPropertiesDiscriminated,
+      "{'kind': 'derived', 'name': 'Derived', 'index': 314, 'age': 2.71828, 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
+    > {}
+
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "For testing"
 @doc("The model is from Record<unknown> type.")
 model IsUnknownAdditionalProperties is Record<unknown> {

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
@@ -142,6 +142,35 @@ interface IsUnknownDerived
       "{'name': 'IsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
+@doc("The model is Record<unknown> with a discriminator.")
+@discriminator("kind")
+model IsUnknownAdditionalPropertiesDiscriminated is Record<unknown> {
+  @doc("The name property")
+  name: string;
+
+  @doc("The discriminator")
+  kind: string;
+}
+
+@doc("The derived discriminated type")
+model IsUnknownAdditionalPropertiesDiscriminatedDerived extends IsUnknownAdditionalPropertiesDiscriminated {
+  kind: "derived";
+
+  @doc("The index property")
+  index: int32;
+
+  @doc("The age property")
+  age?: float32;
+}
+
+@route("/isUnknownDiscriminated")
+@operationGroup
+interface IsUnknownDiscriminated
+  extends ModelOperations<
+      IsUnknownAdditionalPropertiesDiscriminated,
+      "{'kind': 'derived', 'name': 'Derived', 'index': 314, 'age': 2.71828, 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
+    > {}
+
 // ********************************************** Record<string> **********************************************
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "For testing"
 @doc("The model extends from Record<string> type.")

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
@@ -78,7 +78,7 @@ model ExtendsUnknownAdditionalPropertiesDerived extends ExtendsUnknownAdditional
 interface ExtendsUnknownDerived
   extends ModelOperations<
       ExtendsUnknownAdditionalPropertiesDerived,
-      "{'name': 'ExtendsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 42, 'prop2': true, 'prop3': 'abc'}"
+      "{'name': 'ExtendsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "For testing"
@@ -110,7 +110,7 @@ model IsUnknownAdditionalPropertiesDerived extends IsUnknownAdditionalProperties
 interface IsUnknownDerived
   extends ModelOperations<
       IsUnknownAdditionalPropertiesDerived,
-      "{'name': 'IsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 42, 'prop2': true, 'prop3': 'abc'}"
+      "{'name': 'IsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
 // ********************************************** Record<string> **********************************************

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/main.tsp
@@ -64,6 +64,22 @@ interface ExtendsUnknown
       "{'name': 'ExtendsUnknownAdditionalProperties', 'prop1': 32, 'prop2': true, 'prop3': 'abc'}"
     > {}
 
+model ExtendsUnknownAdditionalPropertiesDerived extends ExtendsUnknownAdditionalProperties {
+  @doc("The index property")
+  index: int32;
+
+  @doc("The age property")
+  age?: float32;
+}
+
+@route("/extendsRecordUnknownDerived")
+@operationGroup
+interface ExtendsUnknownDerived
+  extends ModelOperations<
+      ExtendsUnknownAdditionalPropertiesDerived,
+      "{'name': 'ExtendsUnknownAdditionalProperties', 'index': 314, 'age': 2.71828, 'prop1': 42, 'prop2': true, 'prop3': 'abc'}"
+    > {}
+
 #suppress "@azure-tools/typespec-azure-core/bad-record-type" "For testing"
 @doc("The model is from Record<unknown> type.")
 model IsUnknownAdditionalProperties is Record<unknown> {

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
@@ -88,6 +88,18 @@ const isUnknownDerived = createMockApis("isRecordUnknownDerived", {
 Scenarios.Type_Property_AdditionalProperties_IsUnknownDerived_get = passOnSuccess(isUnknownDerived.get);
 Scenarios.Type_Property_AdditionalProperties_IsUnknownDerived_put = passOnSuccess(isUnknownDerived.put);
 
+const isUnknownDiscriminated = createMockApis("isUnknownDiscriminated", {
+  kind: "derived",
+  name: "Derived",
+  index: 314,
+  age: 2.71828,
+  prop1: 32,
+  prop2: true,
+  prop3: "abc",
+});
+Scenarios.Type_Property_AdditionalProperties_IsUnknownDiscriminated_get = passOnSuccess(isUnknownDiscriminated.get);
+Scenarios.Type_Property_AdditionalProperties_IsUnknownDiscriminated_put = passOnSuccess(isUnknownDiscriminated.put);
+
 // **************************************************** Record<string> ****************************************************
 const extendsString = createMockApis("extendsRecordString", {
   name: "ExtendsStringAdditionalProperties",

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
@@ -45,7 +45,7 @@ const extendsUnknownDerived = createMockApis("extendsRecordUnknownDerived", {
   name: "ExtendsUnknownAdditionalProperties",
   index: 314,
   age: 2.71828,
-  prop1: 42,
+  prop1: 32,
   prop2: true,
   prop3: "abc",
 });
@@ -56,7 +56,7 @@ const isUnknownDerived = createMockApis("isRecordUnknownDerived", {
   name: "IsUnknownAdditionalProperties",
   index: 314,
   age: 2.71828,
-  prop1: 42,
+  prop1: 32,
   prop2: true,
   prop3: "abc",
 });

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
@@ -62,7 +62,7 @@ const extendsUnknownDiscriminated = createMockApis("extendsUnknownDiscriminated"
   prop3: "abc",
 });
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDiscriminated_get = passOnSuccess(
-  extendsUnknownDiscriminated.put,
+  extendsUnknownDiscriminated.get,
 );
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDiscriminated_put = passOnSuccess(
   extendsUnknownDiscriminated.put,

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
@@ -52,6 +52,31 @@ const extendsUnknownDerived = createMockApis("extendsRecordUnknownDerived", {
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDerived_get = passOnSuccess(extendsUnknownDerived.get);
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDerived_put = passOnSuccess(extendsUnknownDerived.put);
 
+const extendsUnknownDiscriminated = createMockApis("extendsUnknownDiscriminated", {
+  kind: "derived",
+  name: "Derived",
+  index: 314,
+  age: 2.71828,
+  prop1: 32,
+  prop2: true,
+  prop3: "abc",
+});
+Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDiscriminated_get = passOnSuccess(
+  extendsUnknownDiscriminated.put,
+);
+Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDiscriminated_put = passOnSuccess(
+  extendsUnknownDiscriminated.put,
+);
+
+const isUnknown = createMockApis("isRecordUnknown", {
+  name: "IsUnknownAdditionalProperties",
+  prop1: 32,
+  prop2: true,
+  prop3: "abc",
+});
+Scenarios.Type_Property_AdditionalProperties_IsUnknown_get = passOnSuccess(isUnknown.get);
+Scenarios.Type_Property_AdditionalProperties_IsUnknown_put = passOnSuccess(isUnknown.put);
+
 const isUnknownDerived = createMockApis("isRecordUnknownDerived", {
   name: "IsUnknownAdditionalProperties",
   index: 314,
@@ -62,15 +87,6 @@ const isUnknownDerived = createMockApis("isRecordUnknownDerived", {
 });
 Scenarios.Type_Property_AdditionalProperties_IsUnknownDerived_get = passOnSuccess(isUnknownDerived.get);
 Scenarios.Type_Property_AdditionalProperties_IsUnknownDerived_put = passOnSuccess(isUnknownDerived.put);
-
-const isUnknown = createMockApis("isRecordUnknown", {
-  name: "IsUnknownAdditionalProperties",
-  prop1: 32,
-  prop2: true,
-  prop3: "abc",
-});
-Scenarios.Type_Property_AdditionalProperties_IsUnknown_get = passOnSuccess(isUnknown.get);
-Scenarios.Type_Property_AdditionalProperties_IsUnknown_put = passOnSuccess(isUnknown.put);
 
 // **************************************************** Record<string> ****************************************************
 const extendsString = createMockApis("extendsRecordString", {

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
@@ -41,6 +41,17 @@ const extendsUnknown = createMockApis("extendsRecordUnknown", {
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknown_get = passOnSuccess(extendsUnknown.get);
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknown_put = passOnSuccess(extendsUnknown.put);
 
+const extendsUnknownDerived = createMockApis("extendsRecordUnknownDerived", {
+  name: "ExtendsUnknownAdditionalProperties",
+  index: 314,
+  age: 2.71828,
+  prop1: 42,
+  prop2: true,
+  prop3: "abc",
+});
+Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDerived_get = passOnSuccess(extendsUnknownDerived.get);
+Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDerived_put = passOnSuccess(extendsUnknownDerived.put);
+
 const isUnknown = createMockApis("isRecordUnknown", {
   name: "IsUnknownAdditionalProperties",
   prop1: 32,

--- a/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/additional-properties/mockapi.ts
@@ -52,6 +52,17 @@ const extendsUnknownDerived = createMockApis("extendsRecordUnknownDerived", {
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDerived_get = passOnSuccess(extendsUnknownDerived.get);
 Scenarios.Type_Property_AdditionalProperties_ExtendsUnknownDerived_put = passOnSuccess(extendsUnknownDerived.put);
 
+const isUnknownDerived = createMockApis("isRecordUnknownDerived", {
+  name: "IsUnknownAdditionalProperties",
+  index: 314,
+  age: 2.71828,
+  prop1: 42,
+  prop2: true,
+  prop3: "abc",
+});
+Scenarios.Type_Property_AdditionalProperties_IsUnknownDerived_get = passOnSuccess(isUnknownDerived.get);
+Scenarios.Type_Property_AdditionalProperties_IsUnknownDerived_put = passOnSuccess(isUnknownDerived.put);
+
 const isUnknown = createMockApis("isRecordUnknown", {
   name: "IsUnknownAdditionalProperties",
   prop1: 32,


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
