### PR TITLE
typespec-bump-deps, add `typespec-azure-resource-manager` package

### DIFF
--- a/.changeset/two-bags-marry.md
+++ b/.changeset/two-bags-marry.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/typespec-bump-deps": patch
+---
+
+Add typespec-azure-resource-manager package to typespec-bump-deps

--- a/packages/typespec-bump-deps/src/cli/typespec-bump-deps.ts
+++ b/packages/typespec-bump-deps/src/cli/typespec-bump-deps.ts
@@ -11,6 +11,7 @@ const knownPackages = [
   "@typespec/versioning",
   "@azure-tools/typespec-client-generator-core",
   "@azure-tools/typespec-azure-core",
+  "@azure-tools/typespec-azure-resource-manager",
   "@typespec/eslint-config-typespec",
   "@typespec/library-linter",
 ];


### PR DESCRIPTION
For mpg nightly build.
https://github.com/Azure/autorest.java/blob/5c343ee32e5b1b2b78ce57380cc03c5d02bbe60f/typespec-extension/package.json#L55

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
