### PR TITLE
Split clientName and encodedName tests

### DIFF
--- a/.changeset/fair-suns-jam.md
+++ b/.changeset/fair-suns-jam.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": none
+"@azure-tools/cadl-ranch": none
+---
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "search.exclude": {
     "**/node_modules": true,

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -670,7 +670,7 @@ Expected response body:
 }
 ```
 
-### Client_Naming_header
+### Client_Naming_Header_request
 
 - Endpoint: `post /client/naming/header`
 
@@ -678,6 +678,14 @@ Testing that we can project a header name.
 Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
 
 Expected header parameter: `default-name="true"`
+
+### Client_Naming_Header_response
+
+- Endpoint: `get /client/naming/header`
+
+Testing that we can project a header name.
+Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
+
 Expected response header: `default-name="true"`
 
 ### Client_Naming_Model_client

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -670,6 +670,99 @@ Expected response body:
 }
 ```
 
+### Client_Naming_header
+
+- Endpoint: `post /projection/client-name-and-encoded-name/header`
+
+Testing that we can project a header name.
+Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
+
+Expected header parameter: `default-name="true"`
+Expected response header: `default-name="true"`
+
+### Client_Naming_Model_client
+
+- Endpoint: `post /projection/client-name-and-encoded-name/model/client`
+
+Testing that we can project the client name in our generated SDKs.
+Your generated SDK should generate the model with name `ClientModel`.
+
+Expected request body:
+
+```json
+{ "defaultName": true }
+```
+
+### Client_Naming_Model_language
+
+- Endpoint: `post /projection/client-name-and-encoded-name/model/language`
+
+Testing that we can project the language specific name in our generated SDKs.
+Your generated SDK should generate the model with your language specific model name.
+
+Expected request body:
+
+```json
+{ "defaultName": true }
+```
+
+### Client_Naming_operation
+
+- Endpoint: `post /projection/client-name-and-encoded-name/operation`
+
+Testing that we can project the operation name.
+Your generated SDK should generate an operation called `clientName`.
+
+Expected status code: 204
+
+### Client_Naming_parameter
+
+- Endpoint: `post /projection/client-name-and-encoded-name/parameter`
+
+Testing that we can project a parameter name.
+Your generated SDK should generate an operation `parameter` with a single parameter called `clientName`.
+
+Expected query parameter: `defaultName="true"`
+
+### Client_Naming_Property_client
+
+- Endpoint: `post /projection/client-name-and-encoded-name/property/client`
+
+Testing that we can project the client name in our generated SDKs.
+Your generated SDK should generate ClientNameModel with one property `clientName` with wire name `defaultName`.
+
+Expected request body:
+
+```json
+{ "defaultName": true }
+```
+
+### Client_Naming_Property_compatibleWithEncodedName
+
+- Endpoint: `post /projection/client-name-and-encoded-name/property/compatible-with-encoded-name`
+
+Testing that we can project the client name and the wire name.
+Your generated SDK should generate ClientNameAndJsonEncodedNameModel with one property with client name `clientName` and wire name `wireName`.
+
+Expected request body:
+
+```json
+{ "wireName": true }
+```
+
+### Client_Naming_Property_language
+
+- Endpoint: `post /projection/client-name-and-encoded-name/property/language`
+
+Testing that we can project the language specific name in our generated SDKs.
+Your generated SDK should generate LanguageClientNameModel with one property with your language specific property name and wire name `defaultName`.
+
+Expected request body:
+
+```json
+{ "defaultName": true }
+```
+
 ### Client_Structure_MultiClient
 
 - Endpoints:
@@ -2023,112 +2116,6 @@ maxpagesize=3
 }
 ```
 
-### Projection_ClientNameAndEncodedName_header
-
-- Endpoint: `post /projection/client-name-and-encoded-name/header`
-
-Testing that we can project a header name.
-Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
-
-Expected header parameter: `default-name="true"`
-Expected response header: `default-name="true"`
-
-### Projection_ClientNameAndEncodedName_Model_client
-
-- Endpoint: `post /projection/client-name-and-encoded-name/model/client`
-
-Testing that we can project the client name in our generated SDKs.
-Your generated SDK should generate the model with name `ClientModel`.
-
-Expected request body:
-
-```json
-{ "defaultName": true }
-```
-
-### Projection_ClientNameAndEncodedName_Model_language
-
-- Endpoint: `post /projection/client-name-and-encoded-name/model/language`
-
-Testing that we can project the language specific name in our generated SDKs.
-Your generated SDK should generate the model with your language specific model name.
-
-Expected request body:
-
-```json
-{ "defaultName": true }
-```
-
-### Projection_ClientNameAndEncodedName_operation
-
-- Endpoint: `post /projection/client-name-and-encoded-name/operation`
-
-Testing that we can project the operation name.
-Your generated SDK should generate an operation called `clientName`.
-
-Expected status code: 204
-
-### Projection_ClientNameAndEncodedName_parameter
-
-- Endpoint: `post /projection/client-name-and-encoded-name/parameter`
-
-Testing that we can project a parameter name.
-Your generated SDK should generate an operation `parameter` with a single parameter called `clientName`.
-
-Expected query parameter: `defaultName="true"`
-
-### Projection_ClientNameAndEncodedName_Property_client
-
-- Endpoint: `post /projection/client-name-and-encoded-name/property/client`
-
-Testing that we can project the client name in our generated SDKs.
-Your generated SDK should generate ClientNameModel with one property `clientName` with wire name `defaultName`.
-
-Expected request body:
-
-```json
-{ "defaultName": true }
-```
-
-### Projection_ClientNameAndEncodedName_Property_json
-
-- Endpoint: `post /projection/client-name-and-encoded-name/property/json`
-
-Testing that we can project the JSON name on the wire from defaultName -> wireName.
-Your generated SDK should generate JsonEncodedNameModel with one property `defaultName` with wire name `wireName`.
-
-Expected request body:
-
-```json
-{ "wireName": true }
-```
-
-### Projection_ClientNameAndEncodedName_Property_jsonAndClient
-
-- Endpoint: `post /projection/client-name-and-encoded-name/property/json-and-client`
-
-Testing that we can project the client name and the wire name.
-Your generated SDK should generate ClientNameAndJsonEncodedNameModel with one property with client name `clientName` and wire name `wireName`.
-
-Expected request body:
-
-```json
-{ "wireName": true }
-```
-
-### Projection_ClientNameAndEncodedName_Property_language
-
-- Endpoint: `post /projection/client-name-and-encoded-name/property/language`
-
-Testing that we can project the language specific name in our generated SDKs.
-Your generated SDK should generate LanguageClientNameModel with one property with your language specific property name and wire name `defaultName`.
-
-Expected request body:
-
-```json
-{ "defaultName": true }
-```
-
 ### Projection_ProjectedName_Model_client
 
 - Endpoint: `post /projection/projected-name/model/client`
@@ -2312,6 +2299,33 @@ With the above two calls, we test the following configurations from this service
 - A client generated from the second service spec can call the second deployment of a service with api version v2 with the updated changes
 
 Tests that we can grow up an operation from accepting one required parameter to accepting a required parameter and an optional parameter.
+
+### Serialization_EncodedName_Json_Property_get
+
+- Endpoint: `get /serialization/encoded-name/json/property`
+
+Testing that you deserialize the right json name over the wire.
+
+Your generated SDK should generate JsonEncodedNameModel with one property `defaultName` with wire name `wireName`.
+
+Expected response body:
+
+```json
+{ "wireName": true }
+```
+
+### Serialization_EncodedName_Json_Property_send
+
+- Endpoint: `post /serialization/encoded-name/json/property`
+
+Testing that you send the right JSON name on the wire.
+Your generated SDK should generate JsonEncodedNameModel with one property `defaultName` with wire name `wireName`.
+
+Expected request body:
+
+```json
+{ "wireName": true }
+```
 
 ### Server_Path_Multiple_noOperationParams
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -672,7 +672,7 @@ Expected response body:
 
 ### Client_Naming_header
 
-- Endpoint: `post /projection/client-name-and-encoded-name/header`
+- Endpoint: `post /client/naming/header`
 
 Testing that we can project a header name.
 Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
@@ -682,7 +682,7 @@ Expected response header: `default-name="true"`
 
 ### Client_Naming_Model_client
 
-- Endpoint: `post /projection/client-name-and-encoded-name/model/client`
+- Endpoint: `post /client/naming/model/client`
 
 Testing that we can project the client name in our generated SDKs.
 Your generated SDK should generate the model with name `ClientModel`.
@@ -695,7 +695,7 @@ Expected request body:
 
 ### Client_Naming_Model_language
 
-- Endpoint: `post /projection/client-name-and-encoded-name/model/language`
+- Endpoint: `post /client/naming/model/language`
 
 Testing that we can project the language specific name in our generated SDKs.
 Your generated SDK should generate the model with your language specific model name.
@@ -708,7 +708,7 @@ Expected request body:
 
 ### Client_Naming_operation
 
-- Endpoint: `post /projection/client-name-and-encoded-name/operation`
+- Endpoint: `post /client/naming/operation`
 
 Testing that we can project the operation name.
 Your generated SDK should generate an operation called `clientName`.
@@ -717,7 +717,7 @@ Expected status code: 204
 
 ### Client_Naming_parameter
 
-- Endpoint: `post /projection/client-name-and-encoded-name/parameter`
+- Endpoint: `post /client/naming/parameter`
 
 Testing that we can project a parameter name.
 Your generated SDK should generate an operation `parameter` with a single parameter called `clientName`.
@@ -726,7 +726,7 @@ Expected query parameter: `defaultName="true"`
 
 ### Client_Naming_Property_client
 
-- Endpoint: `post /projection/client-name-and-encoded-name/property/client`
+- Endpoint: `post /client/naming/property/client`
 
 Testing that we can project the client name in our generated SDKs.
 Your generated SDK should generate ClientNameModel with one property `clientName` with wire name `defaultName`.
@@ -739,7 +739,7 @@ Expected request body:
 
 ### Client_Naming_Property_compatibleWithEncodedName
 
-- Endpoint: `post /projection/client-name-and-encoded-name/property/compatible-with-encoded-name`
+- Endpoint: `post /client/naming/property/compatible-with-encoded-name`
 
 Testing that we can project the client name and the wire name.
 Your generated SDK should generate ClientNameAndJsonEncodedNameModel with one property with client name `clientName` and wire name `wireName`.
@@ -752,7 +752,7 @@ Expected request body:
 
 ### Client_Naming_Property_language
 
-- Endpoint: `post /projection/client-name-and-encoded-name/property/language`
+- Endpoint: `post /client/naming/property/language`
 
 Testing that we can project the language specific name in our generated SDKs.
 Your generated SDK should generate LanguageClientNameModel with one property with your language specific property name and wire name `defaultName`.

--- a/packages/cadl-ranch-specs/http/client/naming/main.tsp
+++ b/packages/cadl-ranch-specs/http/client/naming/main.tsp
@@ -13,7 +13,6 @@ using Azure.ClientGenerator.Core;
 namespace Client.Naming;
 
 @route("/property")
-@operationGroup
 namespace Property {
   model LanguageClientNameModel {
     @doc("Pass in true")
@@ -40,42 +39,42 @@ namespace Property {
 
   @scenario
   @scenarioDoc("""
-Testing that we can project the client name in our generated SDKs.
-Your generated SDK should generate ClientNameModel with one property `clientName` with wire name `defaultName`.
+    Testing that we can project the client name in our generated SDKs.
+    Your generated SDK should generate ClientNameModel with one property `clientName` with wire name `defaultName`.
 
-Expected request body:
-```json
-{"defaultName": true}
-```
-""")
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
   @route("/client")
   @post
   op client(...ClientNameModel): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
-Testing that we can project the language specific name in our generated SDKs.
-Your generated SDK should generate LanguageClientNameModel with one property with your language specific property name and wire name `defaultName`.
+    Testing that we can project the language specific name in our generated SDKs.
+    Your generated SDK should generate LanguageClientNameModel with one property with your language specific property name and wire name `defaultName`.
 
-Expected request body:
-```json
-{"defaultName": true}
-```
-""")
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
   @route("/language")
   @post
   op language(...LanguageClientNameModel): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
-Testing that we can project the client name and the wire name.
-Your generated SDK should generate ClientNameAndJsonEncodedNameModel with one property with client name `clientName` and wire name `wireName`.
+    Testing that we can project the client name and the wire name.
+    Your generated SDK should generate ClientNameAndJsonEncodedNameModel with one property with client name `clientName` and wire name `wireName`.
 
-Expected request body:
-```json
-{"wireName": true}
-```
-""")
+    Expected request body:
+    ```json
+    {"wireName": true}
+    ```
+    """)
   @route("/compatible-with-encoded-name")
   @post
   op compatibleWithEncodedName(...ClientNameAndJsonEncodedNameModel): NoContentResponse;
@@ -109,25 +108,36 @@ op parameter(
   defaultName: string,
 ): NoContentResponse;
 
-@scenario
-@scenarioDoc("""
-Testing that we can project a header name.
-Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
-
-Expected header parameter: `default-name="true"`
-Expected response header: `default-name="true"`
-""")
 @route("/header")
-@post
-op header(
-  @clientName("clientName")
-  @header
-  `default-name`: string,
-): {
-  @clientName("clientName")
-  @header
-  `default-name`: string;
-};
+namespace Header {
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project a header name.
+    Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
+
+    Expected header parameter: `default-name="true"`
+    """)
+  @post
+  op request(
+    @clientName("clientName")
+    @header
+    `default-name`: string,
+  ): void;
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project a header name.
+    Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
+
+    Expected response header: `default-name="true"`
+    """)
+  @get
+  op response(): {
+    @clientName("clientName")
+    @header
+    `default-name`: string;
+  };
+}
 
 @route("/model")
 @operationGroup
@@ -151,28 +161,28 @@ namespace Model {
 
   @scenario
   @scenarioDoc("""
-Testing that we can project the client name in our generated SDKs.
-Your generated SDK should generate the model with name `ClientModel`.
+    Testing that we can project the client name in our generated SDKs.
+    Your generated SDK should generate the model with name `ClientModel`.
 
-Expected request body:
-```json
-{"defaultName": true}
-```
-""")
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
   @route("/client")
   @post
   op client(...ModelWithClientClientName): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
-Testing that we can project the language specific name in our generated SDKs.
-Your generated SDK should generate the model with your language specific model name.
+    Testing that we can project the language specific name in our generated SDKs.
+    Your generated SDK should generate the model with your language specific model name.
 
-Expected request body:
-```json
-{"defaultName": true}
-```
-""")
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
   @route("/language")
   @post
   op language(...ModelWithLanguageClientName): NoContentResponse;

--- a/packages/cadl-ranch-specs/http/client/naming/main.tsp
+++ b/packages/cadl-ranch-specs/http/client/naming/main.tsp
@@ -8,7 +8,7 @@ using Azure.ClientGenerator.Core;
 @doc("Projection")
 @supportedBy("dpg")
 @scenarioService("/projection/client-name-and-encoded-name")
-namespace Projection.ClientNameAndEncodedName;
+namespace Client.Naming;
 
 @route("/property")
 @operationGroup
@@ -20,12 +20,6 @@ namespace Property {
     @clientName("JavaName", "java")
     @clientName("TSName", "javascript")
     @clientName("python_name", "python")
-    defaultName: boolean;
-  }
-
-  model JsonEncodedNameModel {
-    @doc("Pass in true")
-    @encodedName("application/json", "wireName")
     defaultName: boolean;
   }
 
@@ -41,20 +35,6 @@ namespace Property {
     @encodedName("application/json", "wireName")
     defaultName: boolean;
   }
-
-  @scenario
-  @scenarioDoc("""
-  Testing that we can project the JSON name on the wire from defaultName -> wireName.
-  Your generated SDK should generate JsonEncodedNameModel with one property `defaultName` with wire name `wireName`.
-
-  Expected request body:
-  ```json
-  {"wireName": true}
-  ```
-  """)
-  @route("/json")
-  @post
-  op json(...JsonEncodedNameModel): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
@@ -94,9 +74,9 @@ Expected request body:
 {"wireName": true}
 ```
 """)
-  @route("/json-and-client")
+  @route("/compatible-with-encoded-name")
   @post
-  op jsonAndClient(...ClientNameAndJsonEncodedNameModel): NoContentResponse;
+  op compatibleWithEncodedName(...ClientNameAndJsonEncodedNameModel): NoContentResponse;
 }
 
 @scenario

--- a/packages/cadl-ranch-specs/http/client/naming/main.tsp
+++ b/packages/cadl-ranch-specs/http/client/naming/main.tsp
@@ -5,9 +5,11 @@ import "@azure-tools/typespec-client-generator-core";
 using TypeSpec.Http;
 using Azure.ClientGenerator.Core;
 
-@doc("Projection")
+/**
+ * Describe changing names of types in a client with `@clientName`
+ */
 @supportedBy("dpg")
-@scenarioService("/projection/client-name-and-encoded-name")
+@scenarioService("/client/naming")
 namespace Client.Naming;
 
 @route("/property")

--- a/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
@@ -47,9 +47,17 @@ Scenarios.Client_Naming_parameter = passOnSuccess(
   }),
 );
 
-Scenarios.Client_Naming_header = passOnSuccess(
+Scenarios.Client_Naming_Header_request = passOnSuccess(
   mockapi.post("/client/naming/header", (req) => {
     req.expect.containsHeader("default-name", "true");
+    return {
+      status: 204,
+    };
+  }),
+);
+
+Scenarios.Client_Naming_Header_response = passOnSuccess(
+  mockapi.post("/client/naming/header", (req) => {
     return {
       status: 204,
       headers: {

--- a/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
@@ -3,17 +3,8 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.Projection_ClientNameAndEncodedName_Property_json = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/property/json", (req) => {
-    req.expect.bodyEquals({ wireName: true });
-    return {
-      status: 204,
-    };
-  }),
-);
-
 Scenarios.Projection_ClientNameAndEncodedName_Property_client = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/property/client", (req) => {
+  mockapi.post("/client/naming/property/client", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
       status: 204,
@@ -22,7 +13,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Property_client = passOnSuccess(
 );
 
 Scenarios.Projection_ClientNameAndEncodedName_Property_language = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/property/language", (req) => {
+  mockapi.post("/client/naming/property/language", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
       status: 204,
@@ -30,8 +21,8 @@ Scenarios.Projection_ClientNameAndEncodedName_Property_language = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_Property_jsonAndClient = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/property/json-and-client", (req) => {
+Scenarios.Projection_ClientNameAndEncodedName_Property_compatibleWithEncodedName = passOnSuccess(
+  mockapi.post("/client/naming/property/compatible-with-encoded-name", (req) => {
     req.expect.bodyEquals({ wireName: true });
     return {
       status: 204,
@@ -40,7 +31,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Property_jsonAndClient = passOnSuc
 );
 
 Scenarios.Projection_ClientNameAndEncodedName_operation = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/operation", (req) => {
+  mockapi.post("/client/naming/operation", (req) => {
     return {
       status: 204,
     };
@@ -48,7 +39,7 @@ Scenarios.Projection_ClientNameAndEncodedName_operation = passOnSuccess(
 );
 
 Scenarios.Projection_ClientNameAndEncodedName_parameter = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/parameter", (req) => {
+  mockapi.post("/client/naming/parameter", (req) => {
     req.expect.containsQueryParam("defaultName", "true");
     return {
       status: 204,
@@ -57,7 +48,7 @@ Scenarios.Projection_ClientNameAndEncodedName_parameter = passOnSuccess(
 );
 
 Scenarios.Projection_ClientNameAndEncodedName_header = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/header", (req) => {
+  mockapi.post("/client/naming/header", (req) => {
     req.expect.containsHeader("default-name", "true");
     return {
       status: 204,
@@ -69,7 +60,7 @@ Scenarios.Projection_ClientNameAndEncodedName_header = passOnSuccess(
 );
 
 Scenarios.Projection_ClientNameAndEncodedName_Model_client = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/model/client", (req) => {
+  mockapi.post("/client/naming/model/client", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
       status: 204,
@@ -78,7 +69,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Model_client = passOnSuccess(
 );
 
 Scenarios.Projection_ClientNameAndEncodedName_Model_language = passOnSuccess(
-  mockapi.post("/projection/client-name-and-encoded-name/model/language", (req) => {
+  mockapi.post("/client/naming/model/language", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
       status: 204,

--- a/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
@@ -3,7 +3,7 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.Projection_ClientNameAndEncodedName_Property_client = passOnSuccess(
+Scenarios.Client_Naming_Property_client = passOnSuccess(
   mockapi.post("/client/naming/property/client", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
@@ -12,7 +12,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Property_client = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_Property_language = passOnSuccess(
+Scenarios.Client_Naming_Property_language = passOnSuccess(
   mockapi.post("/client/naming/property/language", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
@@ -21,7 +21,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Property_language = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_Property_compatibleWithEncodedName = passOnSuccess(
+Scenarios.Client_Naming_Property_compatibleWithEncodedName = passOnSuccess(
   mockapi.post("/client/naming/property/compatible-with-encoded-name", (req) => {
     req.expect.bodyEquals({ wireName: true });
     return {
@@ -30,7 +30,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Property_compatibleWithEncodedName
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_operation = passOnSuccess(
+Scenarios.Client_Naming_operation = passOnSuccess(
   mockapi.post("/client/naming/operation", (req) => {
     return {
       status: 204,
@@ -38,7 +38,7 @@ Scenarios.Projection_ClientNameAndEncodedName_operation = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_parameter = passOnSuccess(
+Scenarios.Client_Naming_parameter = passOnSuccess(
   mockapi.post("/client/naming/parameter", (req) => {
     req.expect.containsQueryParam("defaultName", "true");
     return {
@@ -47,7 +47,7 @@ Scenarios.Projection_ClientNameAndEncodedName_parameter = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_header = passOnSuccess(
+Scenarios.Client_Naming_header = passOnSuccess(
   mockapi.post("/client/naming/header", (req) => {
     req.expect.containsHeader("default-name", "true");
     return {
@@ -59,7 +59,7 @@ Scenarios.Projection_ClientNameAndEncodedName_header = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_Model_client = passOnSuccess(
+Scenarios.Client_Naming_Model_client = passOnSuccess(
   mockapi.post("/client/naming/model/client", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {
@@ -68,7 +68,7 @@ Scenarios.Projection_ClientNameAndEncodedName_Model_client = passOnSuccess(
   }),
 );
 
-Scenarios.Projection_ClientNameAndEncodedName_Model_language = passOnSuccess(
+Scenarios.Client_Naming_Model_language = passOnSuccess(
   mockapi.post("/client/naming/model/language", (req) => {
     req.expect.bodyEquals({ defaultName: true });
     return {

--- a/packages/cadl-ranch-specs/http/serialization/encoded-name/json/main.tsp
+++ b/packages/cadl-ranch-specs/http/serialization/encoded-name/json/main.tsp
@@ -1,0 +1,45 @@
+import "@typespec/http";
+import "@azure-tools/cadl-ranch-expect";
+
+using TypeSpec.Http;
+
+@doc("Projection")
+@supportedBy("dpg")
+@scenarioService("/serialization/encoded-name/json")
+namespace Serialization.EncodedName.Json;
+
+@route("/property")
+namespace Property {
+  model JsonEncodedNameModel {
+    /** Pass in true */
+    @encodedName("application/json", "wireName")
+    defaultName: boolean;
+  }
+
+  @scenario
+  @scenarioDoc("""
+    Testing that you send the right JSON name on the wire.
+    Your generated SDK should generate JsonEncodedNameModel with one property `defaultName` with wire name `wireName`.
+
+    Expected request body:
+    ```json
+    {"wireName": true}
+    ```
+    """)
+  @post
+  op send(...JsonEncodedNameModel): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+    Testing that you deserialize the right json name over the wire.
+
+    Your generated SDK should generate JsonEncodedNameModel with one property `defaultName` with wire name `wireName`.
+
+    Expected response body:
+    ```json
+    {"wireName": true}
+    ```
+    """)
+  @get
+  op get(): JsonEncodedNameModel;
+}

--- a/packages/cadl-ranch-specs/http/serialization/encoded-name/json/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/serialization/encoded-name/json/mockapi.ts
@@ -1,0 +1,21 @@
+import { passOnSuccess, mockapi, json } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Serialization_EncodedName_Json_send = passOnSuccess(
+  mockapi.post("/serialization/encoded-name/json/property", (req) => {
+    req.expect.bodyEquals({ wireName: true });
+    return {
+      status: 204,
+    };
+  }),
+);
+Scenarios.Serialization_EncodedName_Json_get = passOnSuccess(
+  mockapi.get("/serialization/encoded-name/json/property", (req) => {
+    return {
+      status: 200,
+      body: json({ wireName: true }),
+    };
+  }),
+);

--- a/packages/cadl-ranch-specs/http/serialization/encoded-name/json/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/serialization/encoded-name/json/mockapi.ts
@@ -3,7 +3,7 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.Serialization_EncodedName_Json_send = passOnSuccess(
+Scenarios.Serialization_EncodedName_Json_Property_send = passOnSuccess(
   mockapi.post("/serialization/encoded-name/json/property", (req) => {
     req.expect.bodyEquals({ wireName: true });
     return {
@@ -11,7 +11,7 @@ Scenarios.Serialization_EncodedName_Json_send = passOnSuccess(
     };
   }),
 );
-Scenarios.Serialization_EncodedName_Json_get = passOnSuccess(
+Scenarios.Serialization_EncodedName_Json_Property_get = passOnSuccess(
   mockapi.get("/serialization/encoded-name/json/property", (req) => {
     return {
       status: 200,


### PR DESCRIPTION
Previous [PR](https://github.com/Azure/cadl-ranch/pull/511) added those but no new version was released so this isn't breaking anybody 

Splitting the 2 so the naming stays in teh client category and the projected name moves out of the `projection` category that is different.

@msyyc FYI, thanks for the original PR we just noticed that today when looking at the dashboard that it would be better to have this new structure.