### PR TITLE
specs, bug fix on naming header response

### DIFF
--- a/.changeset/flat-donkeys-exist.md
+++ b/.changeset/flat-donkeys-exist.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Bug fix on Scenarios.Client_Naming_Header_response

--- a/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/client/naming/mockapi.ts
@@ -57,7 +57,7 @@ Scenarios.Client_Naming_Header_request = passOnSuccess(
 );
 
 Scenarios.Client_Naming_Header_response = passOnSuccess(
-  mockapi.post("/client/naming/header", (req) => {
+  mockapi.get("/client/naming/header", (req) => {
     return {
       status: 204,
       headers: {


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
