### PR TITLE
remove-customer-scenario-assumption-for-decimal

### DIFF
--- a/.changeset/tall-buses-run.md
+++ b/.changeset/tall-buses-run.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+remove-customer-scenario-assumption-for-decimal

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -6151,23 +6151,6 @@ Expected response body:
 0.33333
 ```
 
-### Type_Scalar_Decimal128Verify_prepareVerify
-
-- Endpoint: `get /type/scalar/decimal128/prepare_verify`
-
-Get verify values:
-[0.1, 0.1, 0.1]
-
-### Type_Scalar_Decimal128Verify_verify
-
-- Endpoint: `post /type/scalar/decimal128/verify`
-
-Expected input body:
-
-```json
-0.3
-```
-
 ### Type_Scalar_DecimalType_requestBody
 
 - Endpoint: `put /type/scalar/decimal/resquest_body`
@@ -6193,23 +6176,6 @@ Expected response body:
 
 ```json
 0.33333
-```
-
-### Type_Scalar_DecimalVerify_prepareVerify
-
-- Endpoint: `get /type/scalar/decimal/prepare_verify`
-
-Get verify values:
-[0.1, 0.1, 0.1]
-
-### Type_Scalar_DecimalVerify_verify
-
-- Endpoint: `post /type/scalar/decimal/verify`
-
-Expected input body:
-
-```json
-0.3
 ```
 
 ### Type_Scalar_String_get

--- a/packages/cadl-ranch-specs/http/type/scalar/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/scalar/main.tsp
@@ -153,13 +153,3 @@ interface NumberTypesVerifyOperations<T, VerifyValues extends string, ResultValu
   @route("/verify")
   verify(@body body: T): void;
 }
-
-@doc("Decimal type verification")
-@route("/decimal")
-@operationGroup
-interface DecimalVerify extends NumberTypesVerifyOperations<decimal, "[0.1, 0.1, 0.1]", "0.3"> {}
-
-@doc("Decimal128 type verification")
-@route("/decimal128")
-@operationGroup
-interface Decimal128Verify extends NumberTypesVerifyOperations<decimal, "[0.1, 0.1, 0.1]", "0.3"> {}


### PR DESCRIPTION
remove the decimal test scenario for 0.1 + 0.1 + 0.1 = 0.3 as it's about customer side scenario, which is out of the scope of cadl ranch testing. If service side expect their customer to use decimal for math calculation, we should suggestion them to use `@encode(string)`, which is pending https://github.com/microsoft/typespec/issues/2762 