### PR TITLE
fix duplicate `@server` definition

### DIFF
--- a/.changeset/strong-beers-fry.md
+++ b/.changeset/strong-beers-fry.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix duplicate `@server` definition

--- a/packages/cadl-ranch-specs/http/server/path/single/main.tsp
+++ b/packages/cadl-ranch-specs/http/server/path/single/main.tsp
@@ -4,7 +4,7 @@ import "@azure-tools/cadl-ranch-expect";
 using TypeSpec.Http;
 
 @doc("Illustrates server with a single path parameter @server")
-@scenarioService("/server/path/single")
+@service
 @server(
   "{endpoint}",
   "Testserver endpoint",
@@ -13,6 +13,7 @@ using TypeSpec.Http;
     endpoint: url,
   }
 )
+@route("/server/path/single")
 namespace Server.Path.Single;
 
 @scenario

--- a/packages/cadl-ranch-specs/http/server/versions/not-versioned/main.tsp
+++ b/packages/cadl-ranch-specs/http/server/versions/not-versioned/main.tsp
@@ -6,7 +6,7 @@ using TypeSpec.Http;
 /**
  * Illustrates not-versioned server.
  */
-@scenarioService("/server/versions/not-versioned")
+@service
 @server(
   "{endpoint}",
   "Testserver endpoint",
@@ -17,6 +17,7 @@ using TypeSpec.Http;
     endpoint: url,
   }
 )
+@route("/server/versions/not-versioned")
 namespace Server.Versions.NotVersioned;
 
 @scenario

--- a/packages/cadl-ranch-specs/http/server/versions/versioned/main.tsp
+++ b/packages/cadl-ranch-specs/http/server/versions/versioned/main.tsp
@@ -9,12 +9,8 @@ using TypeSpec.Versioning;
 /**
  * Illustrates versioned server.
  */
-@scenarioService(
-  "/server/versions/versioned",
-  {
-    versioned: Versions,
-  }
-)
+@service
+@versioned(Versions)
 @server(
   "{endpoint}",
   "Testserver endpoint",
@@ -25,6 +21,7 @@ using TypeSpec.Versioning;
     endpoint: url,
   }
 )
+@route("/server/versions/versioned")
 namespace Server.Versions.Versioned;
 
 /**


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
