### PR TITLE
add float64 case for `encode/duration`

### DIFF
--- a/.changeset/old-poets-repeat.md
+++ b/.changeset/old-poets-repeat.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add float64 test cases for encode/duration

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1351,6 +1351,13 @@ value=1686566864
 Test default encode for a duration header.
 Expected header `input=P40D`
 
+### Encode_Duration_Header_float64Seconds
+
+- Endpoint: `get /encode/duration/header/float64-seconds`
+
+Test float64 seconds encode for a duration header.
+Expected header `duration: 35.621`
+
 ### Encode_Duration_Header_floatSeconds
 
 - Endpoint: `get /encode/duration/header/float-seconds`
@@ -1397,6 +1404,27 @@ Expected response body:
 ```json
 {
   "value": "P40D"
+}
+```
+
+### Encode_Duration_Property_float64Seconds
+
+- Endpoint: `get /encode/duration/property/float64-seconds`
+
+Test operation with request and response model contains a duration property with float seconds encode.
+Expected request body:
+
+```json
+{
+  "value": 35.621
+}
+```
+
+Expected response body:
+
+```json
+{
+  "value": 35.621
 }
 ```
 
@@ -1490,6 +1518,13 @@ Expected response body:
 
 Test default encode for a duration parameter.
 Expected query parameter `input=P40D`
+
+### Encode_Duration_Query_float64Seconds
+
+- Endpoint: `get /encode/duration/query/float64-seconds`
+
+Test float seconds encode for a duration parameter.
+Expected query parameter `input=35.621`
 
 ### Encode_Duration_Query_floatSeconds
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1411,7 +1411,7 @@ Expected response body:
 
 - Endpoint: `get /encode/duration/property/float64-seconds`
 
-Test operation with request and response model contains a duration property with float seconds encode.
+Test operation with request and response model contains a duration property with float64 seconds encode.
 Expected request body:
 
 ```json
@@ -1523,7 +1523,7 @@ Expected query parameter `input=P40D`
 
 - Endpoint: `get /encode/duration/query/float64-seconds`
 
-Test float seconds encode for a duration parameter.
+Test float64 seconds encode for a duration parameter.
 Expected query parameter `input=35.621`
 
 ### Encode_Duration_Query_floatSeconds

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -60,6 +60,18 @@ namespace Query {
     input: duration,
   ): NoContentResponse;
 
+  @route("/float64-seconds")
+  @scenario
+  @scenarioDoc("""
+  Test float seconds encode for a duration parameter.
+  Expected query parameter `input=35.621`
+  """)
+  op float64Seconds(
+    @query
+    @encode(DurationKnownEncoding.seconds, float64)
+    input: duration,
+  ): NoContentResponse;
+
   @encode(DurationKnownEncoding.seconds, int32)
   scalar Int32Duration extends duration;
 
@@ -96,6 +108,11 @@ namespace Property {
 
   model FloatSecondsDurationProperty {
     @encode(DurationKnownEncoding.seconds, float)
+    value: duration;
+  }
+
+  model Float64SecondsDurationProperty {
+    @encode(DurationKnownEncoding.seconds, float64)
     value: duration;
   }
 
@@ -184,6 +201,25 @@ namespace Property {
   """)
   op floatSeconds(@body body: FloatSecondsDurationProperty): FloatSecondsDurationProperty;
 
+  @route("/float64-seconds")
+  @scenario
+  @scenarioDoc("""
+  Test operation with request and response model contains a duration property with float seconds encode.
+  Expected request body:
+  ```json
+  {
+    "value": 35.621
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "value": 35.621
+  }
+  ```
+  """)
+  op float64Seconds(@body body: Float64SecondsDurationProperty): Float64SecondsDurationProperty;
+
   @route("/float-seconds-array")
   @scenario
   @scenarioDoc("""
@@ -267,6 +303,18 @@ namespace Header {
   op floatSeconds(
     @header
     @encode(DurationKnownEncoding.seconds, float)
+    duration: duration,
+  ): NoContentResponse;
+
+  @route("/float64-seconds")
+  @scenario
+  @scenarioDoc("""
+  Test float64 seconds encode for a duration header.
+  Expected header `duration: 35.621`
+  """)
+  op float64Seconds(
+    @header
+    @encode(DurationKnownEncoding.seconds, float64)
     duration: duration,
   ): NoContentResponse;
 }

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -63,7 +63,7 @@ namespace Query {
   @route("/float64-seconds")
   @scenario
   @scenarioDoc("""
-  Test float seconds encode for a duration parameter.
+  Test float64 seconds encode for a duration parameter.
   Expected query parameter `input=35.621`
   """)
   op float64Seconds(
@@ -204,7 +204,7 @@ namespace Property {
   @route("/float64-seconds")
   @scenario
   @scenarioDoc("""
-  Test operation with request and response model contains a duration property with float seconds encode.
+  Test operation with request and response model contains a duration property with float64 seconds encode.
   Expected request body:
   ```json
   {

--- a/packages/cadl-ranch-specs/http/encode/duration/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/duration/mockapi.ts
@@ -41,11 +41,13 @@ Scenarios.Encode_Duration_Query_int32SecondsArray = passOnSuccess(
   createQueryMockApis("int32-seconds-array", ["36", "47"], "csv"),
 );
 Scenarios.Encode_Duration_Query_floatSeconds = passOnSuccess(createQueryMockApis("float-seconds", "35.621"));
+Scenarios.Encode_Duration_Query_float64Seconds = passOnSuccess(createQueryMockApis("float64-seconds", "35.621"));
 
 Scenarios.Encode_Duration_Property_default = passOnSuccess(createPropertyMockApis("default", "P40D"));
 Scenarios.Encode_Duration_Property_iso8601 = passOnSuccess(createPropertyMockApis("iso8601", "P40D"));
 Scenarios.Encode_Duration_Property_int32Seconds = passOnSuccess(createPropertyMockApis("int32-seconds", 36));
 Scenarios.Encode_Duration_Property_floatSeconds = passOnSuccess(createPropertyMockApis("float-seconds", 35.621));
+Scenarios.Encode_Duration_Property_float64Seconds = passOnSuccess(createPropertyMockApis("float64-seconds", 35.621));
 Scenarios.Encode_Duration_Property_floatSecondsArray = passOnSuccess(
   createPropertyMockApis("float-seconds-array", [35.621, 46.781]),
 );
@@ -55,3 +57,4 @@ Scenarios.Encode_Duration_Header_iso8601 = passOnSuccess(createHeaderMockApis("i
 Scenarios.Encode_Duration_Header_iso8601Array = passOnSuccess(createHeaderMockApis("iso8601-array", "P40D,P50D"));
 Scenarios.Encode_Duration_Header_int32Seconds = passOnSuccess(createHeaderMockApis("int32-seconds", "36"));
 Scenarios.Encode_Duration_Header_floatSeconds = passOnSuccess(createHeaderMockApis("float-seconds", "35.621"));
+Scenarios.Encode_Duration_Header_float64Seconds = passOnSuccess(createHeaderMockApis("float64-seconds", "35.621"));


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
