### PR TITLE
specs, remove fixed from enum

### DIFF
--- a/.changeset/wet-tomatoes-yawn.md
+++ b/.changeset/wet-tomatoes-yawn.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Remove fixed from enum.

--- a/packages/cadl-ranch-specs/http/type/enum/fixed/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/enum/fixed/main.tsp
@@ -9,7 +9,6 @@ using TypeSpec.Http;
 namespace Type.Enum.Fixed;
 
 #suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
-@fixed
 @doc("Days of the week")
 enum DaysOfWeekEnum {
   @doc("Monday.")

--- a/packages/cadl-ranch-specs/http/type/model/inheritance/enum-discriminator/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/model/inheritance/enum-discriminator/main.tsp
@@ -35,7 +35,6 @@ model Golden extends Dog {
 
 #suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing fixed enum as discriminator property"
 @doc("fixed enum type for discriminator")
-@fixed
 enum SnakeKind {
   @doc("Species cobra")
   Cobra: "cobra",


### PR DESCRIPTION
All lib should now have removed the `enum`. I assume now we can remove the `@fixed` in test. `enum` there would mean closed enum.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
