### PR TITLE
specs, model used in read-only property should be output

### DIFF
--- a/.changeset/wild-boats-float.md
+++ b/.changeset/wild-boats-float.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add usage test case for model used in read-only property

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -133,6 +133,7 @@ Expected response body:
 - Endpoints:
   - `post /azure/client-generator-core/usage/inputToInputOutput`
   - `post /azure/client-generator-core/usage/outputToInputOutput`
+  - `post /azure/client-generator-core/usage/modelInReadOnlyProperty`
 
 This scenario contains two public operations. Both should be generated and exported.
 The models are override to roundtrip, so they should be generated and exported as well.

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/usage/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/usage/main.tsp
@@ -55,6 +55,37 @@ namespace ModelInOperation {
   @route("/outputToInputOutput")
   @get
   op outputToInputOutput(): OutputModel;
+
+  model ResultModel {
+    name: string;
+  }
+
+  model RoundTripModel {
+    @visibility("read")
+    result: ResultModel;
+  }
+
+  @doc("""
+  "ResultModel" should be usage=output, as it is read-only and does not exist in request body.
+
+  Expected body parameter: 
+  ```json
+  {
+  }
+  ```
+
+  Expected response body: 
+  ```json
+  {
+    "name": <any string>
+  }
+  ```
+  """)
+  @route("/modelInReadOnlyProperty")
+  @put
+  op modelInReadOnlyProperty(@body body: RoundTripModel): {
+    @body body: RoundTripModel;
+  };
 }
 
 @doc("Not used anywhere, but access is override to public so still need to be generated and exported with serialization.")

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/usage/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/usage/mockapi.ts
@@ -15,4 +15,10 @@ Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
       body: json({ name: "Madge" }),
     };
   }),
+  mockapi.put("/azure/client-generator-core/usage/modelInReadOnlyProperty", (req) => {
+    return {
+      status: 200,
+      body: json({ name: "Madge" }),
+    };
+  }),
 ]);


### PR DESCRIPTION
real service
https://github.com/Azure/azure-rest-api-specs/blob/main/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/model.radiologyinsights.tsp#L61-L73

`RadiologyInsightsJob` used in https://github.com/Azure/azure-rest-api-specs/blob/main/specification/ai/HealthInsights/HealthInsights.RadiologyInsights/route.radiologyinsights.tsp#L25, and hence input+output

`RadiologyInsightsInferenceResult` should be usage=output, as the property is read-only

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
