### PR TITLE
specs, explicit body to avoid spread

### DIFF
--- a/.changeset/honest-poems-fix.md
+++ b/.changeset/honest-poems-fix.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Use explicit body to avoid model get spread

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -2085,11 +2085,11 @@ Expected request body:
 
 Test case for spread named model.
 
-Should generate request body model named `BodyParameter`.
+Should not generate request body model named `BodyParameter`.
 Should generate an operation like below:
 
 ```
-spreadAsRequestBody(bodyParameter: BodyParameter)
+spreadAsRequestBody(name: string)
 ```
 
 Note the parameter name is guessed from the model name and it may vary by language.

--- a/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
@@ -96,9 +96,14 @@ Expected response body:
 """)
 @route("/generations:submit")
 op longRunningRpc is global.Azure.Core.LongRunningRpcOperation<
-  {
-    @bodyRoot body: GenerationOptions;
-  },
+  BodyParameter<GenerationOptions>,
   GenerationResponse,
   GenerationResult
 >;
+
+alias BodyParameter<T, TName extends valueof string = "body", TDoc extends valueof string = ""> = {
+  @doc(TDoc)
+  @friendlyName(TName)
+  @bodyRoot
+  body: T;
+};

--- a/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
@@ -95,4 +95,10 @@ Expected response body:
 ```
 """)
 @route("/generations:submit")
-op longRunningRpc is global.Azure.Core.LongRunningRpcOperation<GenerationOptions, GenerationResponse, GenerationResult>;
+op longRunningRpc is global.Azure.Core.LongRunningRpcOperation<
+  {
+    @body body: GenerationOptions;
+  },
+  GenerationResponse,
+  GenerationResult
+>;

--- a/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
@@ -97,7 +97,7 @@ Expected response body:
 @route("/generations:submit")
 op longRunningRpc is global.Azure.Core.LongRunningRpcOperation<
   {
-    @body body: GenerationOptions;
+    @bodyRoot body: GenerationOptions;
   },
   GenerationResponse,
   GenerationResult

--- a/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/lro/rpc/main.tsp
@@ -101,7 +101,7 @@ op longRunningRpc is global.Azure.Core.LongRunningRpcOperation<
   GenerationResult
 >;
 
-alias BodyParameter<T, TName extends valueof string = "body", TDoc extends valueof string = ""> = {
+alias BodyParameter<T, TName extends valueof string = "body", TDoc extends valueof string = "The body parameter."> = {
   @doc(TDoc)
   @friendlyName(TName)
   @bodyRoot

--- a/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
@@ -122,4 +122,10 @@ Expected response body:
 }
 ```
 """)
-op repeatableAction is RepeatableOperationsWithTraits.ResourceAction<User, UserActionParam, UserActionResponse>;
+op repeatableAction is RepeatableOperationsWithTraits.ResourceAction<
+  User,
+  {
+    @body body: UserActionParam;
+  },
+  UserActionResponse
+>;

--- a/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
@@ -125,7 +125,7 @@ Expected response body:
 op repeatableAction is RepeatableOperationsWithTraits.ResourceAction<
   User,
   {
-    @body body: UserActionParam;
+    @bodyRoot body: UserActionParam;
   },
   UserActionResponse
 >;

--- a/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
@@ -128,7 +128,7 @@ op repeatableAction is RepeatableOperationsWithTraits.ResourceAction<
   UserActionResponse
 >;
 
-alias BodyParameter<T, TName extends valueof string = "body", TDoc extends valueof string = ""> = {
+alias BodyParameter<T, TName extends valueof string = "body", TDoc extends valueof string = "The body parameter."> = {
   @doc(TDoc)
   @friendlyName(TName)
   @bodyRoot

--- a/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/traits/main.tsp
@@ -124,8 +124,13 @@ Expected response body:
 """)
 op repeatableAction is RepeatableOperationsWithTraits.ResourceAction<
   User,
-  {
-    @bodyRoot body: UserActionParam;
-  },
+  BodyParameter<UserActionParam>,
   UserActionResponse
 >;
+
+alias BodyParameter<T, TName extends valueof string = "body", TDoc extends valueof string = ""> = {
+  @doc(TDoc)
+  @friendlyName(TName)
+  @bodyRoot
+  body: T;
+};

--- a/packages/cadl-ranch-specs/http/client/naming/main.tsp
+++ b/packages/cadl-ranch-specs/http/client/naming/main.tsp
@@ -173,7 +173,7 @@ namespace Model {
     """)
   @route("/client")
   @post
-  op client(...ModelWithClientClientName): NoContentResponse;
+  op client(@bodyRoot body: ModelWithClientClientName): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
@@ -187,7 +187,7 @@ namespace Model {
     """)
   @route("/language")
   @post
-  op language(...ModelWithLanguageClientName): NoContentResponse;
+  op language(@bodyRoot body: ModelWithLanguageClientName): NoContentResponse;
 }
 
 @operationGroup

--- a/packages/cadl-ranch-specs/http/parameters/spread/main.tsp
+++ b/packages/cadl-ranch-specs/http/parameters/spread/main.tsp
@@ -22,10 +22,10 @@ namespace Model {
   @scenarioDoc("""
   Test case for spread named model. 
   
-  Should generate request body model named `BodyParameter`.
+  Should not generate request body model named `BodyParameter`.
   Should generate an operation like below:
   ```
-  spreadAsRequestBody(bodyParameter: BodyParameter)
+  spreadAsRequestBody(name: string)
   ```
   Note the parameter name is guessed from the model name and it may vary by language.
   

--- a/packages/cadl-ranch-specs/http/serialization/encoded-name/json/main.tsp
+++ b/packages/cadl-ranch-specs/http/serialization/encoded-name/json/main.tsp
@@ -27,7 +27,7 @@ namespace Property {
     ```
     """)
   @post
-  op send(...JsonEncodedNameModel): NoContentResponse;
+  op send(@bodyRoot body: JsonEncodedNameModel): NoContentResponse;
 
   @scenario
   @scenarioDoc("""


### PR DESCRIPTION
To avoid these model getting spread, after the "spread is spread" feature.

We should already had `@body` and `@bodyRoot` in test, for explicit body (non-spread).
I will add a `@bodyIgnore` case in a follow-up PR.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
