### PR TITLE
Use unambiguous float duration values

### DIFF
--- a/.changeset/sweet-dancers-teach.md
+++ b/.changeset/sweet-dancers-teach.md
@@ -1,0 +1,6 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+"@azure-tools/cadl-ranch": patch
+---
+
+Updated expected float duration values (35.621 and 46.781) to the values that can be exactly represented as IEEE754 (35.625 and 46.75 respectively).

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1694,14 +1694,14 @@ Expected header `input=P40D`
 - Endpoint: `get /encode/duration/header/float64-seconds`
 
 Test float64 seconds encode for a duration header.
-Expected header `duration: 35.621`
+Expected header `duration: 35.625`
 
 ### Encode_Duration_Header_floatSeconds
 
 - Endpoint: `get /encode/duration/header/float-seconds`
 
 Test float seconds encode for a duration header.
-Expected header `duration: 35.621`
+Expected header `duration: 35.625`
 
 ### Encode_Duration_Header_int32Seconds
 
@@ -1754,7 +1754,7 @@ Expected request body:
 
 ```json
 {
-  "value": 35.621
+  "value": 35.625
 }
 ```
 
@@ -1762,7 +1762,7 @@ Expected response body:
 
 ```json
 {
-  "value": 35.621
+  "value": 35.625
 }
 ```
 
@@ -1775,7 +1775,7 @@ Expected request body:
 
 ```json
 {
-  "value": 35.621
+  "value": 35.625
 }
 ```
 
@@ -1783,7 +1783,7 @@ Expected response body:
 
 ```json
 {
-  "value": 35.621
+  "value": 35.625
 }
 ```
 
@@ -1796,7 +1796,7 @@ Expected request body:
 
 ```json
 {
-  "value": [35.621, 46.781]
+  "value": [35.625, 46.75]
 }
 ```
 
@@ -1804,7 +1804,7 @@ Expected response body:
 
 ```json
 {
-  "value": [35.621, 46.781]
+  "value": [35.625, 46.75]
 }
 ```
 
@@ -1862,14 +1862,14 @@ Expected query parameter `input=P40D`
 - Endpoint: `get /encode/duration/query/float64-seconds`
 
 Test float64 seconds encode for a duration parameter.
-Expected query parameter `input=35.621`
+Expected query parameter `input=35.625`
 
 ### Encode_Duration_Query_floatSeconds
 
 - Endpoint: `get /encode/duration/query/float-seconds`
 
 Test float seconds encode for a duration parameter.
-Expected query parameter `input=35.621`
+Expected query parameter `input=35.625`
 
 ### Encode_Duration_Query_int32Seconds
 

--- a/packages/cadl-ranch-specs/http/encode/duration/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/duration/main.tsp
@@ -52,7 +52,7 @@ namespace Query {
   @scenario
   @scenarioDoc("""
   Test float seconds encode for a duration parameter.
-  Expected query parameter `input=35.621`
+  Expected query parameter `input=35.625`
   """)
   op floatSeconds(
     @query
@@ -64,7 +64,7 @@ namespace Query {
   @scenario
   @scenarioDoc("""
   Test float64 seconds encode for a duration parameter.
-  Expected query parameter `input=35.621`
+  Expected query parameter `input=35.625`
   """)
   op float64Seconds(
     @query
@@ -189,13 +189,13 @@ namespace Property {
   Expected request body:
   ```json
   {
-    "value": 35.621
+    "value": 35.625
   }
   ```
   Expected response body:
   ```json
   {
-    "value": 35.621
+    "value": 35.625
   }
   ```
   """)
@@ -208,13 +208,13 @@ namespace Property {
   Expected request body:
   ```json
   {
-    "value": 35.621
+    "value": 35.625
   }
   ```
   Expected response body:
   ```json
   {
-    "value": 35.621
+    "value": 35.625
   }
   ```
   """)
@@ -227,13 +227,13 @@ namespace Property {
   Expected request body:
   ```json
   {
-    "value": [35.621, 46.781]
+    "value": [35.625, 46.75]
   }
   ```
   Expected response body:
   ```json
   {
-    "value": [35.621, 46.781]
+    "value": [35.625, 46.75]
   }
   ```
   """)
@@ -298,7 +298,7 @@ namespace Header {
   @scenario
   @scenarioDoc("""
   Test float seconds encode for a duration header.
-  Expected header `duration: 35.621`
+  Expected header `duration: 35.625`
   """)
   op floatSeconds(
     @header
@@ -310,7 +310,7 @@ namespace Header {
   @scenario
   @scenarioDoc("""
   Test float64 seconds encode for a duration header.
-  Expected header `duration: 35.621`
+  Expected header `duration: 35.625`
   """)
   op float64Seconds(
     @header

--- a/packages/cadl-ranch-specs/http/encode/duration/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/duration/mockapi.ts
@@ -40,21 +40,21 @@ Scenarios.Encode_Duration_Query_int32Seconds = passOnSuccess(createQueryMockApis
 Scenarios.Encode_Duration_Query_int32SecondsArray = passOnSuccess(
   createQueryMockApis("int32-seconds-array", ["36", "47"], "csv"),
 );
-Scenarios.Encode_Duration_Query_floatSeconds = passOnSuccess(createQueryMockApis("float-seconds", "35.621"));
-Scenarios.Encode_Duration_Query_float64Seconds = passOnSuccess(createQueryMockApis("float64-seconds", "35.621"));
+Scenarios.Encode_Duration_Query_floatSeconds = passOnSuccess(createQueryMockApis("float-seconds", "35.625"));
+Scenarios.Encode_Duration_Query_float64Seconds = passOnSuccess(createQueryMockApis("float64-seconds", "35.625"));
 
 Scenarios.Encode_Duration_Property_default = passOnSuccess(createPropertyMockApis("default", "P40D"));
 Scenarios.Encode_Duration_Property_iso8601 = passOnSuccess(createPropertyMockApis("iso8601", "P40D"));
 Scenarios.Encode_Duration_Property_int32Seconds = passOnSuccess(createPropertyMockApis("int32-seconds", 36));
-Scenarios.Encode_Duration_Property_floatSeconds = passOnSuccess(createPropertyMockApis("float-seconds", 35.621));
-Scenarios.Encode_Duration_Property_float64Seconds = passOnSuccess(createPropertyMockApis("float64-seconds", 35.621));
+Scenarios.Encode_Duration_Property_floatSeconds = passOnSuccess(createPropertyMockApis("float-seconds", 35.625));
+Scenarios.Encode_Duration_Property_float64Seconds = passOnSuccess(createPropertyMockApis("float64-seconds", 35.625));
 Scenarios.Encode_Duration_Property_floatSecondsArray = passOnSuccess(
-  createPropertyMockApis("float-seconds-array", [35.621, 46.781]),
+  createPropertyMockApis("float-seconds-array", [35.625, 46.75]),
 );
 
 Scenarios.Encode_Duration_Header_default = passOnSuccess(createHeaderMockApis("default", "P40D"));
 Scenarios.Encode_Duration_Header_iso8601 = passOnSuccess(createHeaderMockApis("iso8601", "P40D"));
 Scenarios.Encode_Duration_Header_iso8601Array = passOnSuccess(createHeaderMockApis("iso8601-array", "P40D,P50D"));
 Scenarios.Encode_Duration_Header_int32Seconds = passOnSuccess(createHeaderMockApis("int32-seconds", "36"));
-Scenarios.Encode_Duration_Header_floatSeconds = passOnSuccess(createHeaderMockApis("float-seconds", "35.621"));
-Scenarios.Encode_Duration_Header_float64Seconds = passOnSuccess(createHeaderMockApis("float64-seconds", "35.621"));
+Scenarios.Encode_Duration_Header_floatSeconds = passOnSuccess(createHeaderMockApis("float-seconds", "35.625"));
+Scenarios.Encode_Duration_Header_float64Seconds = passOnSuccess(createHeaderMockApis("float64-seconds", "35.625"));


### PR DESCRIPTION
Same rationale as #516 and #527: for example, when representing `35.621` as float64, `35.62100000000000221689333557151257991790771484375` and `35.621` are the same number (kind of how `42` and `(int)42.1` are the "same number" too), first being explicit and accurate, second one is what will get you to the first one when rounding, assuming 64 bits. (and for 32 bits, `35.621` would be represented as `35.620998382568359375`). I.e. can't reliably expect `35.621.ToString()` to be `35.621` and not `35.62100000000000221689333557151257991790771484375` on all implementations, and should implementation give us `"35.62100000000000221689333557151257991790771484375"`, it won't be incorrect, but cadl-ranch would fail.

If we use `35.625`, it is not ambiguous: `35.625` can be exactly represented as IEEE754 floating point, there is no room for misinterpretations, there is exactly one string representation for it, not two.
So, in this PR, we're updating `35.621` to `35.625`, and `46.781` to `46.75` for the same reason.