### PR TITLE
rename arm tests to resourcemanager

### DIFF
--- a/.changeset/witty-kids-repeat.md
+++ b/.changeset/witty-kids-repeat.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Rename arm tests to resourcemanager

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -71,343 +71,6 @@ Expects header 'x-ms-api-key': 'valid-key'
 
 Expects header 'authorization': 'Bearer https://security.microsoft.com/.default'
 
-### Azure_Arm_Models_Resources_NestedProxyResources_createOrReplace
-
-- Endpoint: `put https://management.azure.com`
-
-Resource PUT operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
-Expected query parameter: api-version=2023-12-01-preview
-Expected request body:
-
-```json
-{
-  "properties": {
-    "description": "valid"
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
-  "name": "nested",
-  "type": "nested",
-  "properties":{
-    "description": "valid",
-    "provisioningState": "Succeeded"
-  },
-  "systemData": {
-    "createdBy": "AzureSDK",
-    "createdByType": "User",
-    "createdAt": <any date>,
-    "lastModifiedBy": "AzureSDK",
-    "lastModifiedAt": <any date>,
-    "lastModifiedByType": "User",
-  }
-}
-```
-
-### Azure_Arm_Models_Resources_NestedProxyResources_delete
-
-- Endpoint: `delete https://management.azure.com`
-
-Resource DELETE operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
-Expected query parameter: api-version=2023-12-01-preview
-Expected response status code: 204
-
-### Azure_Arm_Models_Resources_NestedProxyResources_get
-
-- Endpoint: `get https://management.azure.com`
-
-Resource GET operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
-Expected query parameter: api-version=2023-12-01-preview
-
-Expected response body:
-
-```json
-{
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
-  "name": "nested",
-  "type": "nested",
-  "properties":{
-    "description": "valid",
-    "provisioningState": "Succeeded"
-  },
-  "systemData": {
-    "createdBy": "AzureSDK",
-    "createdByType": "User",
-    "createdAt": <any date>,
-    "lastModifiedBy": "AzureSDK",
-    "lastModifiedAt": <any date>,
-    "lastModifiedByType": "User",
-  }
-}
-```
-
-### Azure_Arm_Models_Resources_NestedProxyResources_listByTopLevelTrackedResource
-
-- Endpoint: `get https://management.azure.com`
-
-Resource LIST by parent resource operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
-Expected query parameter: api-version=2023-12-01-preview
-
-Expected response body:
-
-```json
-{
-  "value": [{
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
-    "name": "nested",
-    "type": "nested",
-    "properties":{
-      "description": "valid",
-      "provisioningState": "Succeeded"
-    },
-    "systemData": {
-      "createdBy": "AzureSDK",
-      "createdByType": "User",
-      "createdAt": <any date>,
-      "lastModifiedBy": "AzureSDK",
-      "lastModifiedAt": <any date>,
-      "lastModifiedByType": "User",
-    }
-  }]
-}
-```
-
-### Azure_Arm_Models_Resources_NestedProxyResources_update
-
-- Endpoint: `patch https://management.azure.com`
-
-Resource PATCH operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
-Expected query parameter: api-version=2023-12-01-preview
-Expected request body:
-
-```json
-{
-  "properties": {
-    "description": "valid2"
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
-  "name": "nested",
-  "type": "nested",
-  "properties":{
-    "description": "valid2",
-    "provisioningState": "Succeeded"
-  },
-  "systemData": {
-    "createdBy": "AzureSDK",
-    "createdByType": "User",
-    "createdAt": <any date>,
-    "lastModifiedBy": "AzureSDK",
-    "lastModifiedAt": <any date>,
-    "lastModifiedByType": "User",
-  }
-}
-```
-
-### Azure_Arm_Models_Resources_TopLevelTrackedResources_createOrReplace
-
-- Endpoint: `put https://management.azure.com`
-
-Resource PUT operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
-Expected query parameter: api-version=2023-12-01-preview
-Expected request body:
-
-```json
-{
-  "location": "eastus",
-  "properties": {
-    "description": "valid"
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
-  "name": "top",
-  "type": "topLevel",
-  "location": "eastus",
-  "properties": {
-    "description": "valid",
-    "provisioningState": "Succeeded"
-  },
-  "systemData": {
-    "createdBy": "AzureSDK",
-    "createdByType": "User",
-    "createdAt": <any date>,
-    "lastModifiedBy": "AzureSDK",
-    "lastModifiedAt": <any date>,
-    "lastModifiedByType": "User",
-  }
-}
-```
-
-### Azure_Arm_Models_Resources_TopLevelTrackedResources_delete
-
-- Endpoint: `delete https://management.azure.com`
-
-Resource DELETE operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
-Expected query parameter: api-version=2023-12-01-preview
-
-````
-Expected response status code: 204
-
-### Azure_Arm_Models_Resources_TopLevelTrackedResources_get
-
-- Endpoint: `get https://management.azure.com`
-
-Resource GET operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
-Expected query parameter: api-version=2023-12-01-preview
-
-Expected response body:
-```json
-{
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
-  "name": "top",
-  "type": "topLevel",
-  "location": "eastus",
-  "properties":{
-    "description": "valid",
-    "provisioningState": "Succeeded"
-  },
-  "systemData": {
-    "createdBy": "AzureSDK",
-    "createdByType": "User",
-    "createdAt": <any date>,
-    "lastModifiedBy": "AzureSDK",
-    "lastModifiedAt": <any date>,
-    "lastModifiedByType": "User",
-  }
-}
-````
-
-### Azure_Arm_Models_Resources_TopLevelTrackedResources_listByResourceGroup
-
-- Endpoint: `get https://management.azure.com`
-
-Resource LIST by resource group operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources
-Expected query parameter: api-version=2023-12-01-preview
-
-Expected response body:
-
-```json
-{
-  "value": [{
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
-    "name": "top",
-    "type": "topLevel",
-    "location": "eastus",
-    "properties":{
-      "description": "valid",
-      "provisioningState": "Succeeded"
-    },
-    "systemData": {
-      "createdBy": "AzureSDK",
-      "createdByType": "User",
-      "createdAt": <any date>,
-      "lastModifiedBy": "AzureSDK",
-      "lastModifiedAt": <any date>,
-      "lastModifiedByType": "User",
-    }
-  }]
-}
-```
-
-### Azure_Arm_Models_Resources_TopLevelTrackedResources_listBySubscription
-
-- Endpoint: `get https://management.azure.com`
-
-Resource LIST by subscription operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources
-Expected query parameter: api-version=2023-12-01-preview
-
-Expected response body:
-
-```json
-{
-  "value": [{
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
-    "name": "top",
-    "type": "topLevel",
-    "location": "eastus",
-    "properties":{
-      "description": "valid",
-      "provisioningState": "Succeeded"
-    },
-    "systemData": {
-      "createdBy": "AzureSDK",
-      "createdByType": "User",
-      "createdAt": <any date>,
-      "lastModifiedBy": "AzureSDK",
-      "lastModifiedAt": <any date>,
-      "lastModifiedByType": "User",
-    }
-  }]
-}
-```
-
-### Azure_Arm_Models_Resources_TopLevelTrackedResources_update
-
-- Endpoint: `patch https://management.azure.com`
-
-Resource PATCH operation.
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
-Expected query parameter: api-version=2023-12-01-preview
-Expected request body:
-
-```json
-{
-  "properties": {
-    "description": "valid2"
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
-  "name": "top",
-  "type": "topLevel",
-  "location": "eastus",
-  "properties":{
-    "description": "valid2",
-    "provisioningState": "Succeeded"
-  },
-  "systemData": {
-    "createdBy": "AzureSDK",
-    "createdByType": "User",
-    "createdAt": <any date>,
-    "lastModifiedBy": "AzureSDK",
-    "lastModifiedAt": <any date>,
-    "lastModifiedByType": "User",
-  }
-}
-```
-
 ### Azure_ClientGenerator_Core_Access_InternalOperation
 
 - Endpoints:
@@ -997,6 +660,343 @@ Expected response body:
 {
   "id": 1,
   "name": "Madge"
+}
+```
+
+### Azure_ResourceManager_Models_Resources_NestedProxyResources_createOrReplace
+
+- Endpoint: `put https://management.azure.com`
+
+Resource PUT operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+Expected query parameter: api-version=2023-12-01-preview
+Expected request body:
+
+```json
+{
+  "properties": {
+    "description": "valid"
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+  "name": "nested",
+  "type": "nested",
+  "properties":{
+    "description": "valid",
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdBy": "AzureSDK",
+    "createdByType": "User",
+    "createdAt": <any date>,
+    "lastModifiedBy": "AzureSDK",
+    "lastModifiedAt": <any date>,
+    "lastModifiedByType": "User",
+  }
+}
+```
+
+### Azure_ResourceManager_Models_Resources_NestedProxyResources_delete
+
+- Endpoint: `delete https://management.azure.com`
+
+Resource DELETE operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+Expected query parameter: api-version=2023-12-01-preview
+Expected response status code: 204
+
+### Azure_ResourceManager_Models_Resources_NestedProxyResources_get
+
+- Endpoint: `get https://management.azure.com`
+
+Resource GET operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+Expected query parameter: api-version=2023-12-01-preview
+
+Expected response body:
+
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+  "name": "nested",
+  "type": "nested",
+  "properties":{
+    "description": "valid",
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdBy": "AzureSDK",
+    "createdByType": "User",
+    "createdAt": <any date>,
+    "lastModifiedBy": "AzureSDK",
+    "lastModifiedAt": <any date>,
+    "lastModifiedByType": "User",
+  }
+}
+```
+
+### Azure_ResourceManager_Models_Resources_NestedProxyResources_listByTopLevelTrackedResource
+
+- Endpoint: `get https://management.azure.com`
+
+Resource LIST by parent resource operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+Expected query parameter: api-version=2023-12-01-preview
+
+Expected response body:
+
+```json
+{
+  "value": [{
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+    "name": "nested",
+    "type": "nested",
+    "properties":{
+      "description": "valid",
+      "provisioningState": "Succeeded"
+    },
+    "systemData": {
+      "createdBy": "AzureSDK",
+      "createdByType": "User",
+      "createdAt": <any date>,
+      "lastModifiedBy": "AzureSDK",
+      "lastModifiedAt": <any date>,
+      "lastModifiedByType": "User",
+    }
+  }]
+}
+```
+
+### Azure_ResourceManager_Models_Resources_NestedProxyResources_update
+
+- Endpoint: `patch https://management.azure.com`
+
+Resource PATCH operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+Expected query parameter: api-version=2023-12-01-preview
+Expected request body:
+
+```json
+{
+  "properties": {
+    "description": "valid2"
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+  "name": "nested",
+  "type": "nested",
+  "properties":{
+    "description": "valid2",
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdBy": "AzureSDK",
+    "createdByType": "User",
+    "createdAt": <any date>,
+    "lastModifiedBy": "AzureSDK",
+    "lastModifiedAt": <any date>,
+    "lastModifiedByType": "User",
+  }
+}
+```
+
+### Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_createOrReplace
+
+- Endpoint: `put https://management.azure.com`
+
+Resource PUT operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+Expected query parameter: api-version=2023-12-01-preview
+Expected request body:
+
+```json
+{
+  "location": "eastus",
+  "properties": {
+    "description": "valid"
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+  "name": "top",
+  "type": "topLevel",
+  "location": "eastus",
+  "properties": {
+    "description": "valid",
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdBy": "AzureSDK",
+    "createdByType": "User",
+    "createdAt": <any date>,
+    "lastModifiedBy": "AzureSDK",
+    "lastModifiedAt": <any date>,
+    "lastModifiedByType": "User",
+  }
+}
+```
+
+### Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_delete
+
+- Endpoint: `delete https://management.azure.com`
+
+Resource DELETE operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+Expected query parameter: api-version=2023-12-01-preview
+
+````
+Expected response status code: 204
+
+### Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_get
+
+- Endpoint: `get https://management.azure.com`
+
+Resource GET operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+Expected query parameter: api-version=2023-12-01-preview
+
+Expected response body:
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+  "name": "top",
+  "type": "topLevel",
+  "location": "eastus",
+  "properties":{
+    "description": "valid",
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdBy": "AzureSDK",
+    "createdByType": "User",
+    "createdAt": <any date>,
+    "lastModifiedBy": "AzureSDK",
+    "lastModifiedAt": <any date>,
+    "lastModifiedByType": "User",
+  }
+}
+````
+
+### Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listByResourceGroup
+
+- Endpoint: `get https://management.azure.com`
+
+Resource LIST by resource group operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources
+Expected query parameter: api-version=2023-12-01-preview
+
+Expected response body:
+
+```json
+{
+  "value": [{
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+    "name": "top",
+    "type": "topLevel",
+    "location": "eastus",
+    "properties":{
+      "description": "valid",
+      "provisioningState": "Succeeded"
+    },
+    "systemData": {
+      "createdBy": "AzureSDK",
+      "createdByType": "User",
+      "createdAt": <any date>,
+      "lastModifiedBy": "AzureSDK",
+      "lastModifiedAt": <any date>,
+      "lastModifiedByType": "User",
+    }
+  }]
+}
+```
+
+### Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listBySubscription
+
+- Endpoint: `get https://management.azure.com`
+
+Resource LIST by subscription operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources
+Expected query parameter: api-version=2023-12-01-preview
+
+Expected response body:
+
+```json
+{
+  "value": [{
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+    "name": "top",
+    "type": "topLevel",
+    "location": "eastus",
+    "properties":{
+      "description": "valid",
+      "provisioningState": "Succeeded"
+    },
+    "systemData": {
+      "createdBy": "AzureSDK",
+      "createdByType": "User",
+      "createdAt": <any date>,
+      "lastModifiedBy": "AzureSDK",
+      "lastModifiedAt": <any date>,
+      "lastModifiedByType": "User",
+    }
+  }]
+}
+```
+
+### Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_update
+
+- Endpoint: `patch https://management.azure.com`
+
+Resource PATCH operation.
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+Expected query parameter: api-version=2023-12-01-preview
+Expected request body:
+
+```json
+{
+  "properties": {
+    "description": "valid2"
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+  "name": "top",
+  "type": "topLevel",
+  "location": "eastus",
+  "properties":{
+    "description": "valid2",
+    "provisioningState": "Succeeded"
+  },
+  "systemData": {
+    "createdBy": "AzureSDK",
+    "createdByType": "User",
+    "createdAt": <any date>,
+    "lastModifiedBy": "AzureSDK",
+    "lastModifiedAt": <any date>,
+    "lastModifiedByType": "User",
+  }
 }
 ```
 

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/main.tsp
@@ -19,11 +19,11 @@ using TypeSpec.OpenAPI;
 @service
 @versioned(Versions)
 @doc("Arm Resource Provider management API.")
-namespace Azure.Arm.Models.Resources;
+namespace Azure.ResourceManager.Models.Resources;
 
 @doc("Azure API versions.")
 enum Versions {
-  @armCommonTypesVersion(CommonTypes.Versions.v5)
+  @armCommonTypesVersion(CommonTypes.Versions.v3)
   @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
   @doc("Preview API version 2023-12-01-preview.")

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/main.tsp
@@ -23,7 +23,7 @@ namespace Azure.ResourceManager.Models.Resources;
 
 @doc("Azure API versions.")
 enum Versions {
-  @armCommonTypesVersion(CommonTypes.Versions.v3)
+  @armCommonTypesVersion(CommonTypes.Versions.v5)
   @useDependency(Azure.Core.Versions.v1_0_Preview_2)
   @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
   @doc("Preview API version 2023-12-01-preview.")

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
@@ -6,9 +6,9 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 const SUBSCRIPTION_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
 const RESOURCE_GROUP_EXPECTED = "test-rg";
 const validTopLevelResource = {
-  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top`,
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top`,
   name: "top",
-  type: "topLevel",
+  type: "Azure.ResourceManager.Models.Resources/topLevelTrackedResources",
   location: "eastus",
   properties: {
     provisioningState: "Succeeded",
@@ -25,9 +25,9 @@ const validTopLevelResource = {
 };
 
 const validNestedResource = {
-  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested`,
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested`,
   name: "nested",
-  type: "nested",
+  type: "Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources",
   properties: {
     provisioningState: "Succeeded",
     description: "valid",
@@ -43,9 +43,9 @@ const validNestedResource = {
 };
 
 // top level tracked resource
-Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_get = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_get = passOnSuccess([
   mockapi.get(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -65,9 +65,9 @@ Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_get = passOnSucces
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_createOrReplace = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_createOrReplace = passOnSuccess([
   mockapi.put(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -84,6 +84,7 @@ Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_createOrReplace = 
         properties: {
           description: "valid",
         },
+        tags: {}, // Workaround here because of https://github.com/Azure/autorest.csharp/issues/4876
       });
       return {
         status: 200,
@@ -93,9 +94,9 @@ Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_createOrReplace = 
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_update = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_update = passOnSuccess([
   mockapi.patch(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -124,9 +125,9 @@ Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_update = passOnSuc
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_delete = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_delete = passOnSuccess([
   mockapi.delete(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -145,9 +146,9 @@ Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_delete = passOnSuc
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_listByResourceGroup = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listByResourceGroup = passOnSuccess([
   mockapi.get(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -166,25 +167,28 @@ Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_listByResourceGrou
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_TopLevelTrackedResources_listBySubscription = passOnSuccess([
-  mockapi.get("/subscriptions/:subscriptionId/providers/Azure.Arm.Models.Resources/topLevelTrackedResources", (req) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError("Unexpected subscriptionId", SUBSCRIPTION_ID_EXPECTED, req.params.subscriptionId);
-    }
-    return {
-      status: 200,
-      body: json({
-        value: [validTopLevelResource],
-      }),
-    };
-  }),
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listBySubscription = passOnSuccess([
+  mockapi.get(
+    "/subscriptions/:subscriptionId/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources",
+    (req) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError("Unexpected subscriptionId", SUBSCRIPTION_ID_EXPECTED, req.params.subscriptionId);
+      }
+      return {
+        status: 200,
+        body: json({
+          value: [validTopLevelResource],
+        }),
+      };
+    },
+  ),
 ]);
 
 // nested proxy resource
-Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_get = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_get = passOnSuccess([
   mockapi.get(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -207,9 +211,9 @@ Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_get = passOnSuccess([
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_createOrReplace = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_createOrReplace = passOnSuccess([
   mockapi.put(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -237,9 +241,9 @@ Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_createOrReplace = pass
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_update = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_update = passOnSuccess([
   mockapi.patch(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
@@ -271,9 +275,9 @@ Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_update = passOnSuccess
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_delete = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_delete = passOnSuccess([
   mockapi.delete(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       return {
@@ -283,9 +287,9 @@ Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_delete = passOnSuccess
   ),
 ]);
 
-Scenarios.Azure_Arm_Models_Resources_NestedProxyResources_listByTopLevelTrackedResource = passOnSuccess([
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_listByTopLevelTrackedResource = passOnSuccess([
   mockapi.get(
-    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources",
+    "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources",
     (req) => {
       req.expect.containsQueryParam("api-version", "2023-12-01-preview");
       if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
@@ -84,7 +84,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_create
         properties: {
           description: "valid",
         },
-        tags: {}, // Workaround here because of https://github.com/Azure/autorest.csharp/issues/4876
       });
       return {
         status: 200,

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/nested.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/nested.tsp
@@ -9,7 +9,7 @@ using Azure.Core;
 using Azure.ResourceManager;
 using TypeSpec.OpenAPI;
 
-namespace Azure.Arm.Models.Resources;
+namespace Azure.ResourceManager.Models.Resources;
 
 @doc("Nested child of Top Level Tracked Resource.")
 @parentResource(TopLevelTrackedResource)
@@ -38,13 +38,13 @@ interface NestedProxyResources {
   @scenario
   @scenarioDoc("""
   Resource GET operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
   Expected query parameter: api-version=2023-12-01-preview
 
   Expected response body:
   ```json
   {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
     "name": "nested",
     "type": "nested",
     "properties":{
@@ -67,7 +67,7 @@ interface NestedProxyResources {
   @scenario
   @scenarioDoc("""
   Resource PUT operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
   Expected query parameter: api-version=2023-12-01-preview
   Expected request body:
   ```json
@@ -80,7 +80,7 @@ interface NestedProxyResources {
   Expected response body:
   ```json
   {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
     "name": "nested",
     "type": "nested",
     "properties":{
@@ -103,7 +103,7 @@ interface NestedProxyResources {
   @scenario
   @scenarioDoc("""
   Resource PATCH operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
   Expected query parameter: api-version=2023-12-01-preview
   Expected request body:
   ```json
@@ -116,7 +116,7 @@ interface NestedProxyResources {
   Expected response body:
   ```json
   {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
     "name": "nested",
     "type": "nested",
     "properties":{
@@ -139,7 +139,7 @@ interface NestedProxyResources {
   @scenario
   @scenarioDoc("""
   Resource DELETE operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
   Expected query parameter: api-version=2023-12-01-preview
   Expected response status code: 204
   """)
@@ -148,14 +148,14 @@ interface NestedProxyResources {
   @scenario
   @scenarioDoc("""
   Resource LIST by parent resource operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
   Expected query parameter: api-version=2023-12-01-preview
 
   Expected response body:
   ```json
   {
     "value": [{
-      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
       "name": "nested",
       "type": "nested",
       "properties":{

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/toplevel.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/toplevel.tsp
@@ -9,7 +9,7 @@ using Azure.Core;
 using Azure.ResourceManager;
 using TypeSpec.OpenAPI;
 
-namespace Azure.Arm.Models.Resources;
+namespace Azure.ResourceManager.Models.Resources;
 
 @resource("topLevelTrackedResources")
 model TopLevelTrackedResource is TrackedResource<TopLevelTrackedResourceProperties> {
@@ -36,13 +36,13 @@ interface TopLevelTrackedResources {
   @scenario
   @scenarioDoc("""
   Resource GET operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
   Expected query parameter: api-version=2023-12-01-preview
 
   Expected response body:
   ```json
   {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
     "name": "top",
     "type": "topLevel",
     "location": "eastus",
@@ -66,7 +66,7 @@ interface TopLevelTrackedResources {
   @scenario
   @scenarioDoc("""
   Resource PUT operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
   Expected query parameter: api-version=2023-12-01-preview
   Expected request body:
   ```json
@@ -80,7 +80,7 @@ interface TopLevelTrackedResources {
   Expected response body:
   ```json
   {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
     "name": "top",
     "type": "topLevel",
     "location": "eastus",
@@ -104,7 +104,7 @@ interface TopLevelTrackedResources {
   @scenario
   @scenarioDoc("""
   Resource PATCH operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
   Expected query parameter: api-version=2023-12-01-preview
   Expected request body:
   ```json
@@ -117,7 +117,7 @@ interface TopLevelTrackedResources {
   Expected response body:
   ```json
   {
-    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
+    "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
     "name": "top",
     "type": "topLevel",
     "location": "eastus",
@@ -141,7 +141,7 @@ interface TopLevelTrackedResources {
   @scenario
   @scenarioDoc("""
   Resource DELETE operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
   Expected query parameter: api-version=2023-12-01-preview
   ```
   Expected response status code: 204
@@ -151,14 +151,14 @@ interface TopLevelTrackedResources {
   @scenario
   @scenarioDoc("""
   Resource LIST by resource group operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources
   Expected query parameter: api-version=2023-12-01-preview
 
   Expected response body:
   ```json
   {
     "value": [{
-      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
       "name": "top",
       "type": "topLevel",
       "location": "eastus",
@@ -183,14 +183,14 @@ interface TopLevelTrackedResources {
   @scenario
   @scenarioDoc("""
   Resource LIST by subscription operation.
-  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources
+  Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources
   Expected query parameter: api-version=2023-12-01-preview
 
   Expected response body:
   ```json
   {
     "value": [{
-      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.Arm.Models.Resources/topLevelTrackedResources/top",
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
       "name": "top",
       "type": "topLevel",
       "location": "eastus",


### PR DESCRIPTION
Arm is in the `.gitignore` of autorest.csharp repo. This is legacy code so that we don't want to touch it. Therefore we want to rename it to resourcemanager.