### PR TITLE
specs, bug fix on explicit body

### DIFF
--- a/.changeset/wicked-eggs-sip.md
+++ b/.changeset/wicked-eggs-sip.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Bug fix for spread.

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -2160,11 +2160,11 @@ Expected request body:
 
 Test case for spread model with non-body http request decorator.
 
-Should generate request body model named `CompositeRequestMix`.
+Should not generate model named `CompositeRequestMix`.
 Should generate an operation like below:
 
 ```
-spreadCompositeRequestMix(name: string, testHeader: string, bodyParameter: CompositeRequestMix)
+spreadCompositeRequestMix(name: string, testHeader: string, prop: string)
 ```
 
 Note the parameter name is guessed from the model name and it may vary by language.

--- a/packages/cadl-ranch-specs/http/client/naming/main.tsp
+++ b/packages/cadl-ranch-specs/http/client/naming/main.tsp
@@ -49,7 +49,7 @@ namespace Property {
     """)
   @route("/client")
   @post
-  op client(...ClientNameModel): NoContentResponse;
+  op client(@body body: ClientNameModel): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
@@ -63,7 +63,7 @@ namespace Property {
     """)
   @route("/language")
   @post
-  op language(...LanguageClientNameModel): NoContentResponse;
+  op language(@body body: LanguageClientNameModel): NoContentResponse;
 
   @scenario
   @scenarioDoc("""
@@ -77,7 +77,7 @@ namespace Property {
     """)
   @route("/compatible-with-encoded-name")
   @post
-  op compatibleWithEncodedName(...ClientNameAndJsonEncodedNameModel): NoContentResponse;
+  op compatibleWithEncodedName(@body body: ClientNameAndJsonEncodedNameModel): NoContentResponse;
 }
 
 @scenario

--- a/packages/cadl-ranch-specs/http/parameters/spread/main.tsp
+++ b/packages/cadl-ranch-specs/http/parameters/spread/main.tsp
@@ -140,10 +140,10 @@ namespace Model {
   @scenarioDoc("""
   Test case for spread model with non-body http request decorator. 
   
-  Should generate request body model named `CompositeRequestMix`.
+  Should not generate model named `CompositeRequestMix`.
   Should generate an operation like below:
   ```
-  spreadCompositeRequestMix(name: string, testHeader: string, bodyParameter: CompositeRequestMix)
+  spreadCompositeRequestMix(name: string, testHeader: string, prop: string)
   ```
   Note the parameter name is guessed from the model name and it may vary by language.
   


### PR DESCRIPTION
There are 2 cases in parameters/spread that behavior changes. scenarioDoc is updated.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
