### PR TITLE
specs, add test scenario for JSON example used in Azure

### DIFF
--- a/.changeset/serious-trains-sneeze.md
+++ b/.changeset/serious-trains-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add a test scenario for JSON example used in Azure

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1043,7 +1043,7 @@ Expected header parameters:
 
 ### Client_AzureExampleClient_basicAction
 
-- Endpoint: `post /basic`
+- Endpoint: `post /azure/example/basic/basic`
 
 Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1041,6 +1041,42 @@ Expected header parameters:
   Expected response header:
 - x-ms-client-request-id=<uuid string same with request header>
 
+### Client_AzureExampleClient_basicAction
+
+- Endpoint: `post /basic`
+
+Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
+
+When generate the code, one need to set the "examples-directory" option.
+
+Expected query parameter: query-param=query&api-version=2022-12-01-preview
+Expected header parameter: header-param=header
+
+Expected input body:
+
+```json
+{
+  "stringProperty": "text",
+  "modelProperty": {
+    "int32Property": 1,
+    "float32Property": 1.5,
+    "enumProperty": "EnumValue1"
+  },
+  "arrayProperty": ["item"],
+  "recordProperty": {
+    "record": "value"
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "stringProperty": "text"
+}
+```
+
 ### Client_Naming_Header_request
 
 - Endpoint: `post /client/naming/header`

--- a/packages/cadl-ranch-specs/http/azure/example/basic/client.tsp
+++ b/packages/cadl-ranch-specs/http/azure/example/basic/client.tsp
@@ -1,0 +1,50 @@
+import "@azure-tools/typespec-client-generator-core";
+
+import "./main.tsp";
+
+using Azure.ClientGenerator.Core;
+
+@TypeSpec.Versioning.useDependency(_Specs_.Azure.Example.Basic.Versions.v2022_12_01_preview)
+namespace Client;
+
+@client({
+  name: "AzureExampleClient",
+  service: _Specs_.Azure.Example.Basic,
+})
+interface AzureExampleClient {
+  @scenario
+  @scenarioDoc("""
+  Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
+
+  When generate the code, one need to set the "examples-directory" option.
+
+  Expected query parameter: query-param=query&api-version=2022-12-01-preview
+  Expected header parameter: header-param=header
+
+  Expected input body:
+  ```json
+  {
+    "stringProperty": "text",
+    "modelProperty": {
+      "int32Property": 1,
+      "float32Property": 1.5,
+      "enumProperty": "EnumValue1"
+    },
+    "arrayProperty": [
+      "item"
+    ],
+    "recordProperty": {
+      "record": "value"
+    }
+  }
+  ```
+
+  Expected response body:
+  ```json
+  {
+    "stringProperty": "text"
+  }
+  ```
+  """)
+  basicAction is _Specs_.Azure.Example.Basic.ServiceOperationGroup.basic;
+}

--- a/packages/cadl-ranch-specs/http/azure/example/basic/examples/2022-12-01-preview/basic.json
+++ b/packages/cadl-ranch-specs/http/azure/example/basic/examples/2022-12-01-preview/basic.json
@@ -1,0 +1,26 @@
+{
+  "operationId": "ServiceOperationGroup_Basic",
+  "title": "Basic action",
+  "parameters": {
+    "api-version": "2022-12-01-preview",
+    "query-param": "query",
+    "header-param": "header",
+    "body": {
+      "stringProperty": "text",
+      "modelProperty": {
+        "int32Property": 1,
+        "float32Property": 1.5,
+        "enumProperty": "EnumValue1"
+      },
+      "arrayProperty": ["item"],
+      "recordProperty": {
+        "record": "value"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "stringProperty": "text"
+    }
+  }
+}

--- a/packages/cadl-ranch-specs/http/azure/example/basic/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/example/basic/main.tsp
@@ -50,7 +50,7 @@ model ActionResponse is ActionRequest;
 
 interface ServiceOperationGroup {
   #suppress "@azure-tools/cadl-ranch-expect/missing-scenario" "scenario defined in client.tsp"
-  @route("/basic")
+  @route("/azure/example/basic/basic")
   @post
   basic(
     ...ApiVersionParameter,

--- a/packages/cadl-ranch-specs/http/azure/example/basic/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/example/basic/main.tsp
@@ -1,0 +1,61 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@azure-tools/cadl-ranch-expect";
+import "@typespec/versioning";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+
+/** Test for loading JSON example and generating sample code. */
+@supportedBy("dpg")
+@scenarioService(
+  "/azure/example/basic",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Example.Basic;
+
+enum Versions {
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+model ApiVersionParameter {
+  @query("api-version")
+  @minLength(1)
+  @doc("The API version to use for this operation.")
+  apiVersion: string;
+}
+
+model ActionRequest {
+  stringProperty: string;
+  modelProperty?: Model;
+  arrayProperty?: Array<string>;
+  recordProperty?: Record<string>;
+}
+
+model Model {
+  int32Property?: int32;
+  float32Property?: float32;
+  enumProperty?: Enum;
+}
+
+union Enum {
+  string,
+  "EnumValue1",
+}
+
+model ActionResponse is ActionRequest;
+
+interface ServiceOperationGroup {
+  #suppress "@azure-tools/cadl-ranch-expect/missing-scenario" "scenario defined in client.tsp"
+  @route("/basic")
+  @post
+  basic(
+    ...ApiVersionParameter,
+    @query("query-param") queryParam: string,
+    @header("header-param") headerParam: string,
+    @body body: ActionRequest,
+  ): ActionResponse;
+}

--- a/packages/cadl-ranch-specs/http/azure/example/basic/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/example/basic/mockapi.ts
@@ -1,0 +1,31 @@
+import { passOnSuccess, mockapi, json } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_AzureExampleClient_basicAction = passOnSuccess(
+  mockapi.patch("/azure/example/basic/basic", (req) => {
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    req.expect.containsQueryParam("query-param", "query");
+    req.expect.containsHeader("header-param", "header");
+    const validBody = {
+      stringProperty: "text",
+      modelProperty: {
+        int32Property: 1,
+        float32Property: 1.5,
+        enumProperty: "EnumValue1",
+      },
+      arrayProperty: ["item"],
+      recordProperty: {
+        record: "value",
+      },
+    };
+    req.expect.bodyEquals(validBody);
+    return {
+      status: 200,
+      body: json({
+        stringProperty: "text",
+      }),
+    };
+  }),
+);

--- a/packages/cadl-ranch-specs/http/azure/example/basic/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/example/basic/mockapi.ts
@@ -4,7 +4,7 @@ import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 Scenarios.Client_AzureExampleClient_basicAction = passOnSuccess(
-  mockapi.patch("/azure/example/basic/basic", (req) => {
+  mockapi.post("/azure/example/basic/basic", (req) => {
     req.expect.containsQueryParam("api-version", "2022-12-01-preview");
     req.expect.containsQueryParam("query-param", "query");
     req.expect.containsHeader("header-param", "header");


### PR DESCRIPTION
Java sample code snippet would look like this
```java
        ActionResponse response = azureExampleClient.basicAction("query", "header",
            new ActionRequest("text")
                .setModelProperty(
                    new Model().setInt32Property(1).setFloat32Property(1.5D).setEnumProperty(Enum.ENUM_VALUE1))
                .setArrayProperty(Arrays.asList("item"))
                .setRecordProperty(mapOf("record", "value")));
```

Pass in Java https://github.com/weidongxu-microsoft/autorest.java/blob/cadl-ranch-example-json/typespec-tests/src/test/java/com/_specs_/azure/example/basic/BasicTests.java

Test likely need to set a `examples-directory` in emitter option, when generating code for this case.

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
