### PR TITLE
ARM resource test, fix `listByParent`

### DIFF
--- a/.changeset/sweet-chicken-punch.md
+++ b/.changeset/sweet-chicken-punch.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+In ARM resource test case, fixed `listByParent` operation name to `listByTopLevelTrackedResource`.

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/nested.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/nested.tsp
@@ -174,5 +174,5 @@ interface NestedProxyResources {
   }
   ```
   """)
-  listByParent is ArmResourceListByParent<NestedProxyResource>;
+  listByTopLevelTrackedResource is ArmResourceListByParent<NestedProxyResource>;
 }


### PR DESCRIPTION
In the next  `typespec-azure-resource-manager`, `armRenameListByOperation` decorator is removed from `ResourceListByParent` operation. 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3960525&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=738c417a-4a48-5620-b571-4f9e77e0bfd2&l=25
This PR fixed the name to avoid breaking after new `typespec-azure-resource-manager` release.
This should not break the existing API.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
