### PR TITLE
Add typespec/openapi3 to typespec-bump-deps

### DIFF
--- a/.changeset/silly-kings-wink.md
+++ b/.changeset/silly-kings-wink.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/typespec-bump-deps": patch
+---
+
+Add `@typespec/openapi3` to typespec-bump-deps

--- a/packages/typespec-bump-deps/src/cli/typespec-bump-deps.ts
+++ b/packages/typespec-bump-deps/src/cli/typespec-bump-deps.ts
@@ -7,6 +7,7 @@ const knownPackages = [
   "@typespec/compiler",
   "@typespec/http",
   "@typespec/openapi",
+  "@typespec/openapi3",
   "@typespec/rest",
   "@typespec/versioning",
   "@typespec/xml",


### PR DESCRIPTION
We have a [test ](https://github.com/Azure/autorest.csharp/blob/b222aaf9cc4ba420322ccd98f45425c2bbca3a49/test/UnbrandedProjects/Platform-OpenAI-TypeSpec/completions/models.tsp#L114)need `typespec/openapi3`.