### PR TITLE
resource-manager, fix resource update call validation

### DIFF
--- a/.changeset/witty-peas-notice.md
+++ b/.changeset/witty-peas-notice.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Fix body check on TrackedResource update.

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
@@ -107,10 +107,8 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_update
       if (req.params.topLevelResourceName.toLowerCase() !== "top") {
         throw new ValidationError("Unexpected top level resource name", "top", req.params.topLevelResourceName);
       }
-      req.expect.bodyEquals({
-        properties: {
-          description: "valid2",
-        },
+      req.expect.deepEqual(req.body.properties, {
+        description: "valid2",
       });
       const resource = {
         ...validTopLevelResource,


### PR DESCRIPTION
`ArmResourcePatchAsync` no longer generate `xxUpdate` models, thus `location` property of the TrackedResource will get serialized during update.
This PR skip the check on bodyEquals, but rather check `properties` itself.

Java's codegen test passed.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
