### PR TITLE
fix some typos in plain date and plain time scenarios

### DIFF
--- a/.changeset/mean-grapes-serve.md
+++ b/.changeset/mean-grapes-serve.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix some typos in plain date and plain time scenarios

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -6443,9 +6443,9 @@ Expected request body:
 {}
 ```
 
-### Type_Property_Optional_Plaindate_getAll
+### Type_Property_Optional_PlainDate_getAll
 
-- Endpoint: `get /type/property/optional/plaindate/all`
+- Endpoint: `get /type/property/optional/plainDate/all`
 
 Expected response body:
 
@@ -6453,9 +6453,9 @@ Expected response body:
 { "property": "2022-12-12" }
 ```
 
-### Type_Property_Optional_Plaindate_getDefault
+### Type_Property_Optional_PlainDate_getDefault
 
-- Endpoint: `get /type/property/optional/plaindate/default`
+- Endpoint: `get /type/property/optional/plainDate/default`
 
 Expected response body:
 
@@ -6463,9 +6463,9 @@ Expected response body:
 {}
 ```
 
-### Type_Property_Optional_Plaindate_putAll
+### Type_Property_Optional_PlainDate_putAll
 
-- Endpoint: `put /type/property/optional/plaindate/all`
+- Endpoint: `put /type/property/optional/plainDate/all`
 
 Expected request body:
 
@@ -6473,9 +6473,9 @@ Expected request body:
 { "property": "2022-12-12" }
 ```
 
-### Type_Property_Optional_Plaindate_putDefault
+### Type_Property_Optional_PlainDate_putDefault
 
-- Endpoint: `put /type/property/optional/plaindate/default`
+- Endpoint: `put /type/property/optional/plainDate/default`
 
 Expected request body:
 
@@ -6483,9 +6483,9 @@ Expected request body:
 {}
 ```
 
-### Type_Property_Optional_Plaintime_getAll
+### Type_Property_Optional_PlainTime_getAll
 
-- Endpoint: `get /type/property/optional/plaintime/all`
+- Endpoint: `get /type/property/optional/plainTime/all`
 
 Expected response body:
 
@@ -6493,9 +6493,9 @@ Expected response body:
 { "property": "13:06:12" }
 ```
 
-### Type_Property_Optional_Plaintime_getDefault
+### Type_Property_Optional_PlainTime_getDefault
 
-- Endpoint: `get /type/property/optional/plaintime/default`
+- Endpoint: `get /type/property/optional/plainTime/default`
 
 Expected response body:
 
@@ -6503,9 +6503,9 @@ Expected response body:
 {}
 ```
 
-### Type_Property_Optional_Plaintime_putAll
+### Type_Property_Optional_PlainTime_putAll
 
-- Endpoint: `put /type/property/optional/plaintime/all`
+- Endpoint: `put /type/property/optional/plainTime/all`
 
 Expected request body:
 
@@ -6513,9 +6513,9 @@ Expected request body:
 { "property": "13:06:12" }
 ```
 
-### Type_Property_Optional_Plaintime_putDefault
+### Type_Property_Optional_PlainTime_putDefault
 
-- Endpoint: `put /type/property/optional/plaintime/default`
+- Endpoint: `put /type/property/optional/plainTime/default`
 
 Expected request body:
 

--- a/packages/cadl-ranch-specs/http/type/property/optionality/main.tsp
+++ b/packages/cadl-ranch-specs/http/type/property/optionality/main.tsp
@@ -112,19 +112,19 @@ model DurationProperty is ModelTemplate<duration>;
 @operationGroup
 interface Duration extends OperationsTemplate<DurationProperty, "\"P123DT22H14M12.011S\""> {}
 
-// Model with optional plaindate property
-@doc("Model with a plaindate property")
-model PlaindateProperty is ModelTemplate<plainDate>;
-@route("/plaindate")
+// Model with optional plainDate property
+@doc("Model with a plainDate property")
+model PlainDateProperty is ModelTemplate<plainDate>;
+@route("/plainDate")
 @operationGroup
-interface Plaindate extends OperationsTemplate<PlaindateProperty, "\"2022-12-12\""> {}
+interface PlainDate extends OperationsTemplate<PlainDateProperty, "\"2022-12-12\""> {}
 
 // Model with optional  property
-@doc("Model with a plaintime property")
+@doc("Model with a plainTime property")
 model PlainTimeProperty is ModelTemplate<plainTime>;
-@route("/plaintime")
+@route("/plainTime")
 @operationGroup
-interface Plaintime extends OperationsTemplate<PlainTimeProperty, "\"13:06:12\""> {}
+interface PlainTime extends OperationsTemplate<PlainTimeProperty, "\"13:06:12\""> {}
 
 // Model with optional collection bytes property
 @doc("Model with collection bytes properties")

--- a/packages/cadl-ranch-specs/http/type/property/optionality/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/optionality/mockapi.ts
@@ -77,17 +77,17 @@ Scenarios.Type_Property_Optional_Duration_getDefault = passOnSuccess(durationMoc
 Scenarios.Type_Property_Optional_Duration_putAll = passOnSuccess(durationMock.putAll);
 Scenarios.Type_Property_Optional_Duration_putDefault = passOnSuccess(durationMock.putDefault);
 
-const plaindateMock = createMockApis("plaindate", "2022-12-12");
-Scenarios.Type_Property_Optional_Plaindate_getAll = passOnSuccess(plaindateMock.getAll);
-Scenarios.Type_Property_Optional_Plaindate_getDefault = passOnSuccess(plaindateMock.getDefault);
-Scenarios.Type_Property_Optional_Plaindate_putAll = passOnSuccess(plaindateMock.putAll);
-Scenarios.Type_Property_Optional_Plaindate_putDefault = passOnSuccess(plaindateMock.putDefault);
+const plainDateMock = createMockApis("plainDate", "2022-12-12");
+Scenarios.Type_Property_Optional_PlainDate_getAll = passOnSuccess(plainDateMock.getAll);
+Scenarios.Type_Property_Optional_PlainDate_getDefault = passOnSuccess(plainDateMock.getDefault);
+Scenarios.Type_Property_Optional_PlainDate_putAll = passOnSuccess(plainDateMock.putAll);
+Scenarios.Type_Property_Optional_PlainDate_putDefault = passOnSuccess(plainDateMock.putDefault);
 
-const plaindatetimeMock = createMockApis("plaintime", "13:06:12");
-Scenarios.Type_Property_Optional_Plaintime_getAll = passOnSuccess(plaindatetimeMock.getAll);
-Scenarios.Type_Property_Optional_Plaintime_getDefault = passOnSuccess(plaindatetimeMock.getDefault);
-Scenarios.Type_Property_Optional_Plaintime_putAll = passOnSuccess(plaindatetimeMock.putAll);
-Scenarios.Type_Property_Optional_Plaintime_putDefault = passOnSuccess(plaindatetimeMock.putDefault);
+const plainTimeMock = createMockApis("plainTime", "13:06:12");
+Scenarios.Type_Property_Optional_PlainTime_getAll = passOnSuccess(plainTimeMock.getAll);
+Scenarios.Type_Property_Optional_PlainTime_getDefault = passOnSuccess(plainTimeMock.getDefault);
+Scenarios.Type_Property_Optional_PlainTime_putAll = passOnSuccess(plainTimeMock.putAll);
+Scenarios.Type_Property_Optional_PlainTime_putDefault = passOnSuccess(plainTimeMock.putDefault);
 
 const collectionsBytesMock = createMockApis("collections/bytes", ["aGVsbG8sIHdvcmxkIQ==", "aGVsbG8sIHdvcmxkIQ=="]);
 Scenarios.Type_Property_Optional_CollectionsByte_getAll = passOnSuccess(collectionsBytesMock.getAll);


### PR DESCRIPTION
The scalar type `plainDate` and `plainTime` are two words in typespec definition, there is no reason that we make a difference in cadl-ranch cases.

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
