### PR TITLE
Publish/cadl ranch 0.13.5

### DIFF
--- a/.changeset/kind-maps-pay.md
+++ b/.changeset/kind-maps-pay.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch": patch
+---
+
+bump-cadl-ranch-version

--- a/.changeset/kind-maps-pay.md
+++ b/.changeset/kind-maps-pay.md
@@ -1,5 +1,0 @@
----
-"@azure-tools/cadl-ranch": patch
----
-
-bump-cadl-ranch-version

--- a/packages/cadl-ranch-specs/CHANGELOG.md
+++ b/packages/cadl-ranch-specs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @azure-tools/cadl-ranch-specs
 
+## 0.34.10
+
+### Patch Changes
+
+- 1cdf0c8: updated dependencies @azure-tools/cadl-ranch-api@0.4.4
+
+
 ## 0.34.9
 
 ### Patch Changes

--- a/packages/cadl-ranch-specs/CHANGELOG.md
+++ b/packages/cadl-ranch-specs/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 - 1cdf0c8: updated dependencies @azure-tools/cadl-ranch-api@0.4.4
 
-
 ## 0.34.9
 
 ### Patch Changes

--- a/packages/cadl-ranch-specs/package.json
+++ b/packages/cadl-ranch-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch-specs",
-  "version": "0.34.9",
+  "version": "0.34.10",
   "description": "Cadl scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/cadl-ranch/CHANGELOG.md
+++ b/packages/cadl-ranch/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @azure-tools/cadl-ranch
 
+## 0.13.5
+
+### Patch Changes
+
+- Updated dependencies [1cdf0c8]
+  - @azure-tools/cadl-ranch-api@0.4.4
+
 ## 0.13.4
 
 ### Patch Changes

--- a/packages/cadl-ranch/CHANGELOG.md
+++ b/packages/cadl-ranch/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 ### Patch Changes
 
-- Updated dependencies [1cdf0c8]
-  - @azure-tools/cadl-ranch-api@0.4.4
+- 1cdf0c8: updated dependencies @azure-tools/cadl-ranch-api@0.4.4
 
 ## 0.13.4
 

--- a/packages/cadl-ranch/package.json
+++ b/packages/cadl-ranch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "description": "Cadl Ranch Tool to validate, run mock api, collect coverage.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
we bumped a new api version for cadl ranch api for xml support https://github.com/Azure/cadl-ranch/commits/main/packages/cadl-ranch-api

but didn't bump the cadl ranch version as cadl-ranch api upgrade. which cause us get unexpected 500 errors as we have two versions of cadl-ranch api resolved.


# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
