### PR TITLE
arm, fix resources mock test

### DIFF
--- a/.changeset/great-lemons-tie.md
+++ b/.changeset/great-lemons-tie.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Fixed resource-manager/resources mock implementation.

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/models/resources/mockapi.ts
@@ -110,9 +110,7 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_update
       req.expect.deepEqual(req.body.properties, {
         description: "valid2",
       });
-      const resource = {
-        ...validTopLevelResource,
-      };
+      const resource = JSON.parse(JSON.stringify(validTopLevelResource));
       resource.properties.description = "valid2";
       return {
         status: 200,
@@ -260,9 +258,7 @@ Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_update = p
           description: "valid2",
         },
       });
-      const resource = {
-        ...validNestedResource,
-      };
+      const resource = JSON.parse(JSON.stringify(validTopLevelResource));
       resource.properties.description = "valid2";
       return {
         status: 200,


### PR DESCRIPTION
the bug will only appear in the second run..

spread is shallow copy, changing in spread model's properties will result in changing in original model's properties
use serialize/deserialize instead


# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
