### PR TITLE
[tcgc] BREAKING: move `type/model/flatten` to `azure/client-generator-core/flatten-property`

### DIFF
--- a/.changeset/proud-numbers-share.md
+++ b/.changeset/proud-numbers-share.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+Move `type/model/flatten` test to `azure/client-generator-core/flatten-property`

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -128,6 +128,70 @@ Expected response body:
 }
 ```
 
+### Azure_ClientGenerator_Core_FlattenProperty_putFlattenModel
+
+- Endpoint: `put /azure/client-generator-core/flatten-property/flattenModel`
+
+Update and receive model with 1 level of flattening.
+Expected input body:
+
+```json
+{
+  "name": "foo",
+  "properties": {
+    "description": "bar",
+    "age": 10
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "name": "test",
+  "properties": {
+    "description": "test",
+    "age": 1
+  }
+}
+```
+
+### Azure_ClientGenerator_Core_FlattenProperty_putNestedFlattenModel
+
+- Endpoint: `put /azure/client-generator-core/flatten-property/nestedFlattenModel`
+
+Update and receive model with 2 levels of flattening.
+Expected input body:
+
+```json
+{
+  "name": "foo",
+  "properties": {
+    "summary": "bar",
+    "properties": {
+      "description": "test",
+      "age": 10
+    }
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "name": "test",
+  "properties": {
+    "summary": "test",
+    "properties": {
+      "description": "foo",
+      "age": 1
+    }
+  }
+}
+```
+
 ### Azure_ClientGenerator_Core_Usage_ModelInOperation
 
 - Endpoints:
@@ -4817,70 +4881,6 @@ Send a POST request with the following body {} which returns the same.
 - Endpoint: `put /type/model/empty/alone`
 
 Send a PUT request with the following body {}
-
-### Type_Model_Flatten_putFlattenModel
-
-- Endpoint: `put /type/model/flatten/flattenModel`
-
-Update and receive model with 1 level of flattening.
-Expected input body:
-
-```json
-{
-  "name": "foo",
-  "properties": {
-    "description": "bar",
-    "age": 10
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "name": "test",
-  "properties": {
-    "description": "test",
-    "age": 1
-  }
-}
-```
-
-### Type_Model_Flatten_putNestedFlattenModel
-
-- Endpoint: `put /type/model/flatten/nestedFlattenModel`
-
-Update and receive model with 2 levels of flattening.
-Expected input body:
-
-```json
-{
-  "name": "foo",
-  "properties": {
-    "summary": "bar",
-    "properties": {
-      "description": "test",
-      "age": 10
-    }
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "name": "test",
-  "properties": {
-    "summary": "test",
-    "properties": {
-      "description": "foo",
-      "age": 1
-    }
-  }
-}
-```
 
 ### Type_Model_Inheritance_EnumDiscriminator_getExtensibleModel
 

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/flatten-property/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/flatten-property/main.tsp
@@ -6,8 +6,8 @@ using TypeSpec.Http;
 using Azure.ClientGenerator.Core;
 
 @doc("Illustrates the model flatten cases.")
-@scenarioService("/type/model/flatten")
-namespace Type.Model.Flatten;
+@scenarioService("/azure/client-generator-core/flatten-property")
+namespace Azure.ClientGenerator.Core.FlattenProperty;
 
 @doc("This is the model with one level of flattening.")
 model FlattenModel {

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/flatten-property/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/flatten-property/mockapi.ts
@@ -2,15 +2,14 @@ import { passOnSuccess, mockapi, json, MockApi } from "@azure-tools/cadl-ranch-a
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
-
 /**
  * Return the put operation.
- * @param route The route under /type/model/flatten for your function.
+ * @param route The route under /azure/client-generator-core/flatten-property for your function.
  * @param request The request body you are expecting and will return.
  * @param response The response body you are expecting and will return.
  */
 function createMockApis(route: string, request: any, response: any): MockApi {
-  const url = `/type/model/flatten/${route}`;
+  const url = `/azure/client-generator-core/flatten-property${route}`;
   return mockapi.put(url, (req) => {
     req.expect.bodyEquals(request);
     return {
@@ -20,7 +19,7 @@ function createMockApis(route: string, request: any, response: any): MockApi {
   });
 }
 
-Scenarios.Type_Model_Flatten_putFlattenModel = passOnSuccess(
+Scenarios.Azure_ClientGenerator_Core_FlattenProperty_putFlattenModel = passOnSuccess(
   createMockApis(
     "flattenModel",
     {
@@ -40,7 +39,7 @@ Scenarios.Type_Model_Flatten_putFlattenModel = passOnSuccess(
   ),
 );
 
-Scenarios.Type_Model_Flatten_putNestedFlattenModel = passOnSuccess(
+Scenarios.Azure_ClientGenerator_Core_FlattenProperty_putNestedFlattenModel = passOnSuccess(
   createMockApis(
     "nestedFlattenModel",
     {


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
