### PR TITLE
Facet Test

### DIFF
--- a/.changeset/young-worms-repeat.md
+++ b/.changeset/young-worms-repeat.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add facet test in azure/core.

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -282,9 +282,23 @@ Expected request body:
 ```json
 {
   "kind": "Int32Values",
-  "values": [10, 20],
+  "ranges": [10, 20],
   "value": 15,
   "field": "price"
+}
+```
+
+Expected response body:
+
+```json
+{
+  "field_name": "price",
+  "results": [
+    {
+      "value": 15,
+      "count": 1
+    }
+  ]
 }
 ```
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -271,6 +271,23 @@ Expected response body:
 }
 ```
 
+### Azure_Core_Facet_getInt32Facets
+
+- Endpoint: `get /azure/core/facet/int32`
+
+Should generate models named Facet, NumericValuesFacet, Int32ValuesFacet, priceresult and FacetResult.
+
+Expected request body:
+
+```json
+{
+  "kind": "Int32Values",
+  "values": [10, 20],
+  "value": 15,
+  "field": "price"
+}
+```
+
 ### Azure_Core_Lro_Rpc_longRunningRpc
 
 - Endpoint: `post /azure/core/lro/rpc/generations:submit`

--- a/packages/cadl-ranch-specs/http/azure/core/facet/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/facet/main.tsp
@@ -1,0 +1,81 @@
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/cadl-ranch-expect";
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+
+using Azure.Core;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "For spec"
+@doc("Illustrates bodies templated with Azure Core with facet support")
+@scenarioService(
+  "/azure/core/facet",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Facet;
+
+@doc("The version of the API.")
+enum Versions {
+  @doc("The version 2022-12-01-preview.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+@doc("Facet")
+model Facet {
+  @doc("A field to facet by, where the field is attributed as 'facetable'")
+  field: string;
+}
+
+model NumericValuesFacet<T extends numeric> extends Facet {
+  @doc("The facet ranges to produce. The values must be listed in ascending order to get the expected results.")
+  values: T[];
+
+  value: T;
+}
+
+@doc("Facets an int32 field by the specified value ranges.")
+model Int32ValuesFacet extends NumericValuesFacet<int32> {
+  @doc("The facet type.")
+  kind: "Int32Values";
+}
+
+model priceresult {
+  @doc("facet value")
+  value: int32;
+
+  @doc("total count")
+  count: int32;
+}
+
+@doc("Facet result")
+model FacetResult {
+  @doc("The facet value.")
+  field_name: "price";
+
+  results: priceresult[];
+}
+
+@scenario
+@doc("Facets an int32 field by the specified value ranges.")
+@route("/int32")
+@scenarioDoc("""
+  Should generate models named Facet, NumericValuesFacet, Int32ValuesFacet, priceresult and FacetResult.
+  
+  Expected request body:
+  ```json
+  {
+    "kind": "Int32Values",
+    "values": [10, 20],
+    "value": 15,
+    "field": "price"
+  }
+  ```
+  """)
+@get
+op getInt32Facets(@body input: Int32ValuesFacet): FacetResult;

--- a/packages/cadl-ranch-specs/http/azure/core/facet/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/facet/main.tsp
@@ -34,7 +34,7 @@ model Facet {
 
 model NumericValuesFacet<T extends numeric> extends Facet {
   @doc("The facet ranges to produce. The values must be listed in ascending order to get the expected results.")
-  values: T[];
+  ranges: T[];
 
   value: T;
 }
@@ -71,9 +71,21 @@ model FacetResult {
   ```json
   {
     "kind": "Int32Values",
-    "values": [10, 20],
+    "ranges": [10, 20],
     "value": 15,
     "field": "price"
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "field_name": "price",
+    "results": [
+      {
+        "value": 15,
+        "count": 1
+      },
+    ]
   }
   ```
   """)

--- a/packages/cadl-ranch-specs/http/azure/core/facet/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/facet/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
+import { passOnSuccess, mockapi, json } from "@azure-tools/cadl-ranch-api";
 import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/cadl-ranch-specs/http/azure/core/facet/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/facet/mockapi.ts
@@ -1,0 +1,23 @@
+import { passOnSuccess, mockapi, json, ValidationError } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+const priceResult = { value: 15, count: 1 };
+const expectInputBody = {
+  kind: "Int32Values",
+  ranges: [10, 20],
+  value: 15,
+  field: "price",
+};
+
+const responseBody = {
+  field_name: "price",
+  results: [priceResult],
+};
+
+Scenarios.Azure_Core_Facet_getInt32Facets = passOnSuccess(
+  mockapi.get("/azure/core/facet/int32", (req) => {
+    req.expect.bodyEquals(expectInputBody);
+    return { status: 200, body: json(responseBody) };
+  }),
+);


### PR DESCRIPTION
To migrate the [Models-TypeSpec](https://github.com/Azure/autorest.csharp/blob/68e44c384b4809bb4c1e989571ba19f081c3ff48/test/TestProjects/Models-TypeSpec/Models-TypeSpec.tsp#L533) from the autorest test project to cadl ranch, and specifically to handle the migration of the facet operation.
