### PR TITLE
specs, minor change to avoid deprecated query param options

### DIFF
--- a/.changeset/curly-cobras-learn.md
+++ b/.changeset/curly-cobras-learn.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Minor change to avoid deprecated query parameter options.

--- a/packages/cadl-ranch-specs/http/client/structure/client-operation-group/client.tsp
+++ b/packages/cadl-ranch-specs/http/client/structure/client-operation-group/client.tsp
@@ -61,7 +61,7 @@ namespace Client.Structure.ClientOperationGroup {
     name: "SecondClient",
     service: Client.Structure.Service,
   },
-  "javascript"
+  "javascript,go"
 )
 namespace Client.Structure.AnotherClientOperationGroup {
   op five is Client.Structure.Service.Bar.five;

--- a/packages/cadl-ranch-specs/http/parameters/collection-format/main.tsp
+++ b/packages/cadl-ranch-specs/http/parameters/collection-format/main.tsp
@@ -19,11 +19,8 @@ namespace Query {
     """)
   @route("/multi")
   op multi(
-    #suppress "deprecated" "Deprecated in next release"
     @doc("Possible values for colors are [blue,red,green]")
-    @query({
-      format: "multi",
-    })
+    @query(#{ explode: true })
     colors: string[],
   ): NoContentResponse;
 
@@ -75,12 +72,8 @@ namespace Query {
     """)
   @route("/csv")
   op csv(
-    #suppress "deprecated" "Deprecated in next release"
-    #suppress "deprecated" "Deprecated in next release"
     @doc("Possible values for colors are [blue,red,green]")
-    @query({
-      format: "csv",
-    })
+    @query
     colors: string[],
   ): NoContentResponse;
 }
@@ -94,7 +87,6 @@ namespace Header {
     """)
   @route("/csv")
   op csv(
-    #suppress "deprecated" "Deprecated in next release"
     @doc("Possible values for colors are [blue,red,green]")
     @header({
       format: "csv",


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
