### PR TITLE
Fix NameSpace In Flatten-Property

### DIFF
--- a/.changeset/forty-brooms-fix.md
+++ b/.changeset/forty-brooms-fix.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": minor
+---
+
+Fix some minor issues in the namespace of azure/client-generate-core/flatten-property.

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/flatten-property/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/flatten-property/main.tsp
@@ -3,11 +3,11 @@ import "@azure-tools/cadl-ranch-expect";
 import "@azure-tools/typespec-client-generator-core";
 
 using TypeSpec.Http;
-using Azure.ClientGenerator.Core;
+using global.Azure.ClientGenerator.Core;
 
 @doc("Illustrates the model flatten cases.")
 @scenarioService("/azure/client-generator-core/flatten-property")
-namespace Azure.ClientGenerator.Core.FlattenProperty;
+namespace _Specs_.Azure.ClientGenerator.Core.FlattenProperty;
 
 @doc("This is the model with one level of flattening.")
 model FlattenModel {


### PR DESCRIPTION
The namespace in flatten-property caused code generation errors in autorest.csharp. This PR fixes this issue.