### PR TITLE
refactor(spec): add uint8 for int encoding and templatize

### DIFF
--- a/.changeset/lemon-walls-attend.md
+++ b/.changeset/lemon-walls-attend.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+refactor(spec): replace uint32 with uint8 for int encoding

--- a/.changeset/lemon-walls-attend.md
+++ b/.changeset/lemon-walls-attend.md
@@ -2,4 +2,4 @@
 "@azure-tools/cadl-ranch-specs": patch
 ---
 
-refactor(spec): replace uint32 with uint8 for int encoding
+refactor(spec): add uint8 for int encoding and templatize

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -2413,7 +2413,7 @@ Expected response body:
 }
 ```
 
-### Encode_Numeric_Property_uint8AsStringOptional
+### Encode_Numeric_Property_uint8AsString
 
 - Endpoint: `post /encode/numeric/property/uint8`
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -2246,16 +2246,16 @@ Expected response body:
 }
 ```
 
-### Encode_Numeric_Property_uint32AsStringOptional
+### Encode_Numeric_Property_uint8AsStringOptional
 
-- Endpoint: `post /encode/numeric/property/uint32`
+- Endpoint: `post /encode/numeric/property/uint8`
 
-Test operation with request and response model contains property of uint32 type with string encode.
+Test operation with request and response model contains property of uint8 type with string encode.
 Expected request body:
 
 ```json
 {
-  "value": "1"
+  "value": "255"
 }
 ```
 
@@ -2263,7 +2263,7 @@ Expected response body:
 
 ```json
 {
-  "value": "1"
+  "value": "255"
 }
 ```
 

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -2246,6 +2246,27 @@ Expected response body:
 }
 ```
 
+### Encode_Numeric_Property_uint32AsStringOptional
+
+- Endpoint: `post /encode/numeric/property/uint32`
+
+Test operation with request and response model contains property of uint32 type with string encode.
+Expected request body:
+
+```json
+{
+  "value": "1"
+}
+```
+
+Expected response body:
+
+```json
+{
+  "value": "1"
+}
+```
+
 ### Encode_Numeric_Property_uint8AsStringOptional
 
 - Endpoint: `post /encode/numeric/property/uint8`

--- a/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
@@ -40,7 +40,7 @@ namespace Property {
 
   model Uint8AsStringProperty {
     @encode(string)
-    value?: uint8;
+    value: uint8;
   }
 
   interface SendIntAsString<IntType extends integer, StringValue extends string, Payload> {

--- a/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
@@ -38,28 +38,28 @@ namespace Property {
     value: safeint;
   }
 
-  @route("/uint32")
+  @route("/uint8")
   @scenario
   @scenarioDoc("""
-    Test operation with request and response model contains property of uint32 type with string encode.
+    Test operation with request and response model contains property of uint8 type with string encode.
     Expected request body:
     ```json
     {
-      "value": "1"
+      "value": "255"
     }
     ```
     Expected response body:
     ```json
     {
-      "value": "1"
+      "value": "255"
     }
     ```
     """)
   @post
-  op uint32AsStringOptional(@body body: Uint32AsStringProperty): Uint32AsStringProperty;
+  op uint8AsStringOptional(@body body: Uint8AsStringProperty): Uint8AsStringProperty;
 
-  model Uint32AsStringProperty {
+  model Uint8AsStringProperty {
     @encode(string)
-    value?: uint32;
+    value?: uint8;
   }
 }

--- a/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
@@ -13,78 +13,60 @@ namespace Encode.Numeric;
 @operationGroup
 @route("/property")
 namespace Property {
+  alias SendSafeIntAsString = SendIntAsString<safeint, "10000000000", SafeintAsStringProperty>;
+
   @route("/safeint")
-  @scenario
-  @scenarioDoc("""
-    Test operation with request and response model contains property of safeint type with string encode.
-    Expected request body:
-    ```json
-    {
-      "value": "10000000000"
-    }
-    ```
-    Expected response body:
-    ```json
-    {
-      "value": "10000000000"
-    }
-    ```
-    """)
-  @post
-  op safeintAsString(@body body: SafeintAsStringProperty): SafeintAsStringProperty;
+  op safeintAsString is SendSafeIntAsString.sendIntAsString;
 
   model SafeintAsStringProperty {
     @encode(string)
     value: safeint;
   }
 
+  alias SendUint32AsString = SendIntAsString<uint32, "1", Uint32AsStringProperty>;
+
   @route("/uint32")
-  @scenario
-  @scenarioDoc("""
-    Test operation with request and response model contains property of uint32 type with string encode.
-    Expected request body:
-    ```json
-    {
-      "value": "1"
-    }
-    ```
-    Expected response body:
-    ```json
-    {
-      "value": "1"
-    }
-    ```
-    """)
-  @post
-  op uint32AsStringOptional(@body body: Uint32AsStringProperty): Uint32AsStringProperty;
+  op uint32AsStringOptional is SendUint32AsString.sendIntAsString;
 
   model Uint32AsStringProperty {
     @encode(string)
     value?: uint32;
   }
 
+  alias SendUint8AsString = SendIntAsString<uint8, "255", Uint8AsStringProperty>;
+
   @route("/uint8")
-  @scenario
-  @scenarioDoc("""
-    Test operation with request and response model contains property of uint8 type with string encode.
-    Expected request body:
-    ```json
-    {
-      "value": "255"
-    }
-    ```
-    Expected response body:
-    ```json
-    {
-      "value": "255"
-    }
-    ```
-    """)
-  @post
-  op uint8AsStringOptional(@body body: Uint8AsStringProperty): Uint8AsStringProperty;
+  op uint8AsStringOptional is SendUint8AsString.sendIntAsString;
 
   model Uint8AsStringProperty {
     @encode(string)
     value?: uint8;
+  }
+
+  interface SendIntAsString<IntType extends integer, StringValue extends string, Payload> {
+    @scenario
+    @scenarioDoc(
+      """
+        Test operation with request and response model contains property of {type} type with string encode.
+        Expected request body:
+        ```json
+        {
+          "value": "{value}"
+        }
+        ```
+        Expected response body:
+        ```json
+        {
+          "value": "{value}"
+        }
+        ```
+        """,
+      {
+        type: IntType,
+        value: StringValue,
+      }
+    )
+    @post
+    sendIntAsString(@body value: Payload): Payload;
   }
 }

--- a/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
@@ -38,6 +38,31 @@ namespace Property {
     value: safeint;
   }
 
+  @route("/uint32")
+  @scenario
+  @scenarioDoc("""
+    Test operation with request and response model contains property of uint32 type with string encode.
+    Expected request body:
+    ```json
+    {
+      "value": "1"
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "value": "1"
+    }
+    ```
+    """)
+  @post
+  op uint32AsStringOptional(@body body: Uint32AsStringProperty): Uint32AsStringProperty;
+
+  model Uint32AsStringProperty {
+    @encode(string)
+    value?: uint32;
+  }
+
   @route("/uint8")
   @scenario
   @scenarioDoc("""

--- a/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
+++ b/packages/cadl-ranch-specs/http/encode/numeric/main.tsp
@@ -36,7 +36,7 @@ namespace Property {
   alias SendUint8AsString = SendIntAsString<uint8, "255", Uint8AsStringProperty>;
 
   @route("/uint8")
-  op uint8AsStringOptional is SendUint8AsString.sendIntAsString;
+  op uint8AsString is SendUint8AsString.sendIntAsString;
 
   model Uint8AsStringProperty {
     @encode(string)

--- a/packages/cadl-ranch-specs/http/encode/numeric/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/numeric/mockapi.ts
@@ -18,4 +18,4 @@ Scenarios.Encode_Numeric_Property_safeintAsString = passOnSuccess(createProperty
 
 Scenarios.Encode_Numeric_Property_uint32AsStringOptional = passOnSuccess(createPropertyMockApis("uint32", "1"));
 
-Scenarios.Encode_Numeric_Property_uint8AsStringOptional = passOnSuccess(createPropertyMockApis("uint8", "255"));
+Scenarios.Encode_Numeric_Property_uint8AsString = passOnSuccess(createPropertyMockApis("uint8", "255"));

--- a/packages/cadl-ranch-specs/http/encode/numeric/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/numeric/mockapi.ts
@@ -16,4 +16,4 @@ function createPropertyMockApis(route: string, value: string): MockApi {
 
 Scenarios.Encode_Numeric_Property_safeintAsString = passOnSuccess(createPropertyMockApis("safeint", "10000000000"));
 
-Scenarios.Encode_Numeric_Property_uint32AsStringOptional = passOnSuccess(createPropertyMockApis("uint32", "1"));
+Scenarios.Encode_Numeric_Property_uint8AsStringOptional = passOnSuccess(createPropertyMockApis("uint8", "255"));

--- a/packages/cadl-ranch-specs/http/encode/numeric/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/numeric/mockapi.ts
@@ -16,4 +16,6 @@ function createPropertyMockApis(route: string, value: string): MockApi {
 
 Scenarios.Encode_Numeric_Property_safeintAsString = passOnSuccess(createPropertyMockApis("safeint", "10000000000"));
 
+Scenarios.Encode_Numeric_Property_uint32AsStringOptional = passOnSuccess(createPropertyMockApis("uint32", "1"));
+
 Scenarios.Encode_Numeric_Property_uint8AsStringOptional = passOnSuccess(createPropertyMockApis("uint8", "255"));


### PR DESCRIPTION
- .net doesn't support uint32 yet, so use uint8
- use a value which will be negative in signed int

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
