### PR TITLE
Revert "fix(decorator): replace hard code url with `{endpoint}` in `@scenarioService` (#598)"

### DIFF
--- a/.changeset/pretty-lobsters-grow.md
+++ b/.changeset/pretty-lobsters-grow.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-expect": patch
+---
+
+Revert PR 598

--- a/packages/cadl-ranch-expect/src/decorators.ts
+++ b/packages/cadl-ranch-expect/src/decorators.ts
@@ -238,20 +238,6 @@ export function $scenarioService(
     derivedModels: [],
     projectionsByName: [],
   } as any);
-
-  context.call($server, target, "{endpoint}", "Test server endpoint", {
-    kind: "Model",
-    properties: new Map().set("endpoint", {
-      name: "endpoint",
-      type: context.program!.getGlobalNamespaceType().namespaces.get("TypeSpec")!.scalars.get("string"),
-      defaultValue: { entityKind: "Value", valueKind: "StringValue", value: "http://localhost:3000" },
-    }),
-    decorators: [],
-    projections: [],
-    name: "parameters",
-    derivedModels: [],
-    projectionsByName: [],
-  } as any);
-
+  context.call($server, target, "http://localhost:3000", "TestServer endpoint");
   context.call($route, target, route);
 }


### PR DESCRIPTION
This reverts commit 039ab07e8cc5ee9c7805fd3a656eaebb66260aec.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
