### PR TITLE
cadl-ranch-specs, case for access/usage on namespace

### DIFF
--- a/.changeset/smart-llamas-camp.md
+++ b/.changeset/smart-llamas-camp.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Add test case for access/usage on namespace.

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -128,6 +128,22 @@ Expected response body:
 }
 ```
 
+### Azure_ClientGenerator_Core_AccessNamespace_InternalOperation
+
+- Endpoint: `get /azure/client-generator-core/access-namespace/internal-output`
+
+This scenario contains access/usage on namespaces.
+`internalOutput` operation should be internal. `OutputModel` model should be internal + output.
+`Model1` and `Model2` models should be public + output.
+
+Expected response body:
+
+```json
+{
+  "name": <any string>
+}
+```
+
 ### Azure_ClientGenerator_Core_FlattenProperty_putFlattenModel
 
 - Endpoint: `put /azure/client-generator-core/flatten-property/flattenModel`

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/main.tsp
@@ -1,0 +1,36 @@
+import "@typespec/http";
+import "@azure-tools/cadl-ranch-expect";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using global.Azure.ClientGenerator.Core;
+
+@doc("Test for access/usage decorator.")
+@supportedBy("dpg")
+@scenarioService("/azure/client-generator-core/access-namespace")
+namespace _Specs_.Azure.ClientGenerator.Core.AccessNamespace;
+
+// this model should be access=internal and usage=output
+model OutputModel {
+  name: string;
+}
+
+// all the oprations and models within this interface should be access=internal
+@access(Access.internal)
+namespace InternalOperations {
+  @get
+  op output(): OutputModel;
+}
+
+// all the models within this namespace should be access=public and usage=output
+@access(Access.public)
+@usage(Usage.output)
+namespace Models {
+  model Model1 {
+    ref: Model2;
+  }
+
+  model Model2 {
+    name: string;
+  }
+}

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/main.tsp
@@ -15,7 +15,7 @@ model OutputModel {
   name: string;
 }
 
-// all the oprations and models within this interface should be access=internal
+// all the operations and models within this interface should be access=internal
 @scenario
 @scenarioDoc("""
   This scenario contains access/usage on namespaces.

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/main.tsp
@@ -16,10 +16,24 @@ model OutputModel {
 }
 
 // all the oprations and models within this interface should be access=internal
+@scenario
+@scenarioDoc("""
+  This scenario contains access/usage on namespaces.
+  `internalOutput` operation should be internal. `OutputModel` model should be internal + output.
+  `Model1` and `Model2` models should be public + output.
+  
+  Expected response body:
+  ```json
+  {
+    "name": <any string>
+  }
+  ```
+  """)
 @access(Access.internal)
-namespace InternalOperations {
+namespace InternalOperation {
+  @route("/internal-output")
   @get
-  op output(): OutputModel;
+  op internalOutput(): OutputModel;
 }
 
 // all the models within this namespace should be access=public and usage=output

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/access-namespace/mockapi.ts
@@ -1,0 +1,10 @@
+import { passOnSuccess, mockapi, ValidationError, json, MockApi } from "@azure-tools/cadl-ranch-api";
+import { ScenarioMockApi } from "@azure-tools/cadl-ranch-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Azure_ClientGenerator_Core_AccessNamespace_InternalOperation = passOnSuccess(
+  mockapi.get("/azure/client-generator-core/access-namespace/internal-output", (req) => {
+    return { status: 200, body: json({ name: "Madge" }) };
+  }),
+);


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
