### PR TITLE
fix explode query check of mockapi for routes test case

### DIFF
--- a/.changeset/thin-radios-help.md
+++ b/.changeset/thin-radios-help.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix explode query check of mockapi for routes test case

--- a/packages/cadl-ranch-specs/http/routes/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/routes/mockapi.ts
@@ -7,8 +7,25 @@ function defineUri(uri: string) {
   const url = new URL("http://example.com" + uri);
   return passOnSuccess(
     mockapi.get(url.pathname, (req) => {
+      const queryMap = new Map<string, string | string[]>();
       for (const [key, value] of url.searchParams.entries()) {
-        req.expect.containsQueryParam(key, value);
+        if (queryMap.has(key)) {
+          const existing = queryMap.get(key)!;
+          if (Array.isArray(existing)) {
+            existing.push(value);
+          } else {
+            queryMap.set(key, [existing, value]);
+          }
+        } else {
+          queryMap.set(key, value);
+        }
+      }
+      for (const [key, value] of queryMap.entries()) {
+        if (Array.isArray(value)) {
+          req.expect.containsQueryParam(key, value, "multi");
+        } else {
+          req.expect.containsQueryParam(key, value);
+        }
       }
       for (const param of Object.keys(req.query)) {
         if (!url.searchParams.has(param)) {


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.


fix: https://github.com/Azure/cadl-ranch/issues/731