### PR TITLE
fix wrong mock api introduced by #741

### DIFF
--- a/.changeset/cuddly-dragons-retire.md
+++ b/.changeset/cuddly-dragons-retire.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix wrong mock api introduced by #741

--- a/packages/cadl-ranch-specs/http/azure/core/basic/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/core/basic/mockapi.ts
@@ -111,10 +111,10 @@ Scenarios.Azure_Core_Basic_list = passOnSuccess({
     req.expect.containsQueryParam("skip", "10");
     req.expect.containsQueryParam("orderby", "id");
     req.expect.containsQueryParam("filter", "id lt 10");
-    if (!req.originalRequest.originalUrl.includes("select[]=id&select[]=orders&select[]=etag")) {
+    if (!req.originalRequest.originalUrl.includes("select=id&select=orders&select=etag")) {
       throw new ValidationError(
-        "Expected query param select[]=id&select[]=orders&select[]=etag ",
-        "select[]=id&select[]=orders&select[]=etag",
+        "Expected query param select=id&select=orders&select=etag ",
+        "select=id&select=orders&select=etag",
         req.originalRequest.originalUrl,
       );
     }

--- a/packages/cadl-ranch-specs/http/encode/bytes/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/encode/bytes/mockapi.ts
@@ -217,11 +217,11 @@ Scenarios.Encode_Bytes_RequestBody_base64 = createRequestBodyServerTests(
 );
 Scenarios.Encode_Bytes_RequestBody_base64url = createRequestBodyServerTests(
   "/encode/bytes/body/request/base64url",
-  '"dGVzdA=="',
+  '"dGVzdA"',
   {
     "Content-Type": "application/json",
   },
-  '"dGVzdA=="',
+  '"dGVzdA"',
 );
 function createResponseBodyServerTests(
   uri: string,

--- a/packages/cadl-ranch-specs/http/parameters/body-optionality/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/parameters/body-optionality/mockapi.ts
@@ -48,16 +48,12 @@ Scenarios.Parameters_BodyOptionality_OptionalExplicit = passOnSuccess([
   {
     uri: "/parameters/body-optionality/optional-explicit/omit",
     method: "post",
-    request: {
-      body: {
-        name: "foo",
-      },
-    },
+    request: {},
     response: {
       status: 204,
     },
     handler: (req: MockRequest) => {
-      req.expect.bodyEquals({ name: "foo" });
+      req.expect.rawBodyEquals(undefined);
       return { status: 204 };
     },
     kind: "MockApiDefinition",


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
