### PR TITLE
specs, fix mockapi for explode array in routes query

### DIFF
--- a/.changeset/serious-penguins-sniff.md
+++ b/.changeset/serious-penguins-sniff.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Fix explode array mockapi in routes.

--- a/packages/cadl-ranch-specs/http/routes/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/routes/mockapi.ts
@@ -110,7 +110,7 @@ Scenarios.Routes_QueryParameters_QueryExpansion_Explode_primitive = createTests(
   "/routes/query/query-expansion/explode/primitive?param=a",
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_array = createTests(
-  "/routes/query/query-expansion/explode/array?param=a,b",
+  "/routes/query/query-expansion/explode/array?param=a&param=b",
 );
 Scenarios.Routes_QueryParameters_QueryExpansion_Explode_record = createTests(
   "/routes/query/query-expansion/explode/record?a=1&b=2",
@@ -129,7 +129,7 @@ Scenarios.Routes_QueryParameters_QueryContinuation_Explode_primitive = createTes
   "/routes/query/query-continuation/explode/primitive?fixed=true&param=a",
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_array = createTests(
-  "/routes/query/query-continuation/explode/array?fixed=true&param=a,b",
+  "/routes/query/query-continuation/explode/array?fixed=true&param=a&param=b",
 );
 Scenarios.Routes_QueryParameters_QueryContinuation_Explode_record = createTests(
   "/routes/query/query-continuation/explode/record?fixed=true&a=1&b=2",


### PR DESCRIPTION
Tested with Java.

Will migrate to microsoft/typespec, if this one is OK.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
