### PR TITLE
fix(test): adopt `coercedBodyEquals`

### DIFF
--- a/.changeset/perfect-balloons-obey.md
+++ b/.changeset/perfect-balloons-obey.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+fix(test): adopt `coercedBodyEquals`

--- a/packages/cadl-ranch-specs/http/type/property/nullable/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/nullable/mockapi.ts
@@ -36,7 +36,7 @@ function createServerTests(url: string, value: unknown, patchNullableProperty?: 
         status: 204,
       },
       handler: (req: MockRequest) => {
-        req.expect.bodyEquals({
+        req.expect.coercedBodyEquals({
           requiredProperty: "foo",
           nullableProperty: patchNullableProperty || null,
         });

--- a/packages/cadl-ranch-specs/http/type/property/optionality/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/type/property/optionality/mockapi.ts
@@ -30,7 +30,7 @@ function createServerTests(url: string, value: unknown) {
         status: 204,
       },
       handler: (req: MockRequest) => {
-        req.expect.bodyEquals(value);
+        req.expect.coercedBodyEquals(value);
         return {
           status: 204,
         };


### PR DESCRIPTION
For some cases (like Datetime), we should use `coercedBodyEquals` instead of `bodyEquals`

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
