### PR TITLE
specs, back port https://github.com/microsoft/typespec/pull/4713

### DIFF
--- a/.changeset/late-falcons-behave.md
+++ b/.changeset/late-falcons-behave.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Back port fix on route mockapi.

--- a/packages/cadl-ranch-specs/http/routes/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/routes/mockapi.ts
@@ -5,34 +5,29 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 function createTests(uri: string) {
   const url = new URL("http://example.com" + uri);
-  const searchParams = url.searchParams;
-  const params: Record<string, any> = {};
-  for (const [key, value] of searchParams) {
-    params[key] = value;
+  const queryMap = new Map<string, string | string[]>();
+  for (const [key, value] of url.searchParams.entries()) {
+    if (queryMap.has(key)) {
+      const existing = queryMap.get(key)!;
+      if (Array.isArray(existing)) {
+        existing.push(value);
+      } else {
+        queryMap.set(key, [existing, value]);
+      }
+    } else {
+      queryMap.set(key, value);
+    }
   }
   return passOnSuccess({
     uri: url.pathname,
     method: "get",
     request: {
-      params,
+      params: Object.fromEntries(queryMap),
     },
     response: {
       status: 204,
     },
     handler: (req: MockRequest) => {
-      const queryMap = new Map<string, string | string[]>();
-      for (const [key, value] of url.searchParams.entries()) {
-        if (queryMap.has(key)) {
-          const existing = queryMap.get(key)!;
-          if (Array.isArray(existing)) {
-            existing.push(value);
-          } else {
-            queryMap.set(key, [existing, value]);
-          }
-        } else {
-          queryMap.set(key, value);
-        }
-      }
       for (const [key, value] of queryMap.entries()) {
         if (Array.isArray(value)) {
           req.expect.containsQueryParam(key, value, "multi");


### PR DESCRIPTION
back port https://github.com/microsoft/typespec/pull/4713
This probably have not effect on cadl-ranch. Just back port this, in case.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
