### PR TITLE
ARM test, backport fix singleton mockapi.ts

### DIFF
--- a/.changeset/lucky-cups-tie.md
+++ b/.changeset/lucky-cups-tie.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Fixed ARM singleton resource mock test.

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1172,7 +1172,6 @@ Expected request body:
 
 ```json
 {
-  "location": "eastus",
   "properties": {
     "description": "valid2"
   }

--- a/packages/cadl-ranch-specs/cadl-ranch-summary.md
+++ b/packages/cadl-ranch-specs/cadl-ranch-summary.md
@@ -1172,7 +1172,7 @@ Expected request body:
 
 ```json
 {
-  "location": "eastus2",
+  "location": "eastus",
   "properties": {
     "description": "valid2"
   }
@@ -1186,7 +1186,7 @@ Expected response body:
   "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Resources/singletonTrackedResources/default",
   "name": "default",
   "type": "Azure.ResourceManager.Resources/singletonTrackedResources",
-  "location": "eastus2",
+  "location": "eastus",
   "properties":{
     "description": "valid2",
     "provisioningState": "Succeeded"

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/resources/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/resources/mockapi.ts
@@ -112,7 +112,7 @@ Scenarios.Azure_ResourceManager_Resources_Singleton_update = passOnSuccess({
       "api-version": "2023-12-01-preview",
     },
     body: {
-      location: "eastus2",
+      location: "eastus",
       properties: {
         description: "valid2",
       },
@@ -125,7 +125,7 @@ Scenarios.Azure_ResourceManager_Resources_Singleton_update = passOnSuccess({
     status: 200,
     body: json({
       ...validSingletonResource,
-      location: "eastus2",
+      location: "eastus",
       properties: {
         provisioningState: "Succeeded",
         description: "valid2",

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/resources/mockapi.ts
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/resources/mockapi.ts
@@ -112,7 +112,6 @@ Scenarios.Azure_ResourceManager_Resources_Singleton_update = passOnSuccess({
       "api-version": "2023-12-01-preview",
     },
     body: {
-      location: "eastus",
       properties: {
         description: "valid2",
       },
@@ -125,7 +124,6 @@ Scenarios.Azure_ResourceManager_Resources_Singleton_update = passOnSuccess({
     status: 200,
     body: json({
       ...validSingletonResource,
-      location: "eastus",
       properties: {
         provisioningState: "Succeeded",
         description: "valid2",

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/resources/singleton.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/resources/singleton.tsp
@@ -104,7 +104,7 @@ interface Singleton {
     Expected request body:
     ```json
     {
-      "location": "eastus2",
+      "location": "eastus",
       "properties": {
         "description": "valid2"
       }
@@ -116,7 +116,7 @@ interface Singleton {
       "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Resources/singletonTrackedResources/default",
       "name": "default",
       "type": "Azure.ResourceManager.Resources/singletonTrackedResources",
-      "location": "eastus2",
+      "location": "eastus",
       "properties":{
         "description": "valid2",
         "provisioningState": "Succeeded"

--- a/packages/cadl-ranch-specs/http/azure/resource-manager/resources/singleton.tsp
+++ b/packages/cadl-ranch-specs/http/azure/resource-manager/resources/singleton.tsp
@@ -104,7 +104,6 @@ interface Singleton {
     Expected request body:
     ```json
     {
-      "location": "eastus",
       "properties": {
         "description": "valid2"
       }


### PR DESCRIPTION
backport fix from typespec-azure: https://github.com/Azure/typespec-azure/pull/1712

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
