### PR TITLE
Bump versions

### DIFF
--- a/.changeset/lucky-cups-tie.md
+++ b/.changeset/lucky-cups-tie.md
@@ -1,5 +1,0 @@
----
-"@azure-tools/cadl-ranch-specs": patch
----
-
-Fixed ARM singleton resource mock test.

--- a/.changeset/poor-deers-happen.md
+++ b/.changeset/poor-deers-happen.md
@@ -1,6 +1,0 @@
----
-"@azure-tools/cadl-ranch-specs": minor
-"@azure-tools/cadl-ranch": minor
----
-
-Remove handler code and commonapi file

--- a/packages/cadl-ranch-specs/CHANGELOG.md
+++ b/packages/cadl-ranch-specs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @azure-tools/cadl-ranch-specs
 
+## 0.39.0
+
+### Minor Changes
+
+- caa2290: Remove handler code and commonapi file
+
+### Patch Changes
+
+- 43638ce: Fixed ARM singleton resource mock test.
+- Updated dependencies [caa2290]
+  - @azure-tools/cadl-ranch@0.16.0
+
 ## 0.38.0
 
 ### Minor Changes

--- a/packages/cadl-ranch-specs/package.json
+++ b/packages/cadl-ranch-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch-specs",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "Cadl scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",

--- a/packages/cadl-ranch/CHANGELOG.md
+++ b/packages/cadl-ranch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @azure-tools/cadl-ranch
 
+## 0.16.0
+
+### Minor Changes
+
+- caa2290: Remove handler code and commonapi file
+
 ## 0.15.0
 
 ### Minor Changes

--- a/packages/cadl-ranch/package.json
+++ b/packages/cadl-ranch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-ranch",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "Cadl Ranch Tool to validate, run mock api, collect coverage.",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Java doesn't find breaking changes in test.

# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
