### PR TITLE
specs, clientNamespace

### DIFF
--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/client-namespace/client.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/client-namespace/client.tsp
@@ -26,7 +26,7 @@ namespace Client;
 interface ClientNamespaceFirstClient {
   get is First.get;
 }
-@@clientNamespace(FirstModel, "azure.clientgenerator.core.clientnamespace.firstt", "java");
+@@clientNamespace(FirstModel, "azure.clientgenerator.core.clientnamespace.first", "java");
 
 @client({
   name: "ClientNamespaceSecondClient",

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/client-namespace/client.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/client-namespace/client.tsp
@@ -1,0 +1,40 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using global.Azure.ClientGenerator.Core;
+using _Specs_.Azure.ClientGenerator.Core.ClientNamespace;
+
+@scenario
+@scenarioDoc("""
+  Expected client namespace for clients:
+  - ClientNamespaceFirstClient: Azure.ClientGenerator.Core.ClientNamespace
+  - ClientNamespaceSecondClient: Azure.ClientGenerator.Core.ClientNamespace.Second
+  
+  Expected client namespace for models:
+  - FirstClientResult: Azure.ClientGenerator.Core.ClientNamespace.First
+  - SecondClientResult: Azure.ClientGenerator.Core.ClientNamespace.Second
+  - SecondClientEnumType: Azure.ClientGenerator.Core.ClientNamespace.Second.Sub
+  """)
+namespace Client;
+
+@client({
+  name: "ClientNamespaceFirstClient",
+  service: _Specs_.Azure.ClientGenerator.Core.ClientNamespace,
+})
+@clientNamespace("azure.clientgenerator.core.clientnamespace", "java")
+interface ClientNamespaceFirstClient {
+  get is First.get;
+}
+@@clientNamespace(FirstModel, "azure.clientgenerator.core.clientnamespace.firstt", "java");
+
+@client({
+  name: "ClientNamespaceSecondClient",
+  service: _Specs_.Azure.ClientGenerator.Core.ClientNamespace,
+})
+@clientNamespace("azure.clientgenerator.core.clientnamespace.second", "java")
+namespace ClientNamespaceSecondClient {
+  op get is _Specs_.Azure.ClientGenerator.Core.ClientNamespace.Second.get;
+}
+@@clientNamespace(Second.Model, "azure.clientgenerator.core.clientnamespace.second", "java");
+@@clientNamespace(Second.Model.SecondClientEnumType, "azure.clientgenerator.core.clientnamespace.second.sub", "java");

--- a/packages/cadl-ranch-specs/http/azure/client-generator-core/client-namespace/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/client-generator-core/client-namespace/main.tsp
@@ -1,0 +1,39 @@
+import "@typespec/http";
+import "@azure-tools/cadl-ranch-expect";
+
+using TypeSpec.Http;
+
+/** Illustrates the clientNamespace cases. */
+@scenarioService("/azure/client-generator-core/client-namespace")
+namespace _Specs_.Azure.ClientGenerator.Core.ClientNamespace;
+
+interface First {
+  #suppress "@azure-tools/cadl-ranch-expect/missing-scenario" "scenario defined in client.tsp"
+  @route("/first")
+  @get
+  get(): FirstModel.FirstClientResult;
+}
+
+namespace FirstModel {
+  model FirstClientResult {
+    name: string;
+  }
+}
+
+namespace Second {
+  #suppress "@azure-tools/cadl-ranch-expect/missing-scenario" "scenario defined in client.tsp"
+  @route("/second")
+  @get
+  op get(): Model.SecondClientResult;
+
+  namespace Model {
+    model SecondClientResult {
+      type: SecondClientEnumType;
+    }
+
+    union SecondClientEnumType {
+      string,
+      "type",
+    }
+  }
+}


### PR DESCRIPTION
fix https://github.com/Azure/cadl-ranch/issues/758

This scenario mainly test the case when `@clientNamespace` applied to TypeSpec Namespace/Interface/Model/Enum.

So far it does not test corner cases, like client/subclient in different namespace, name conflict for model in different namespace, etc.

# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
