### PR TITLE
Remove use of azure next link

### DIFF
--- a/.changeset/rare-seahorses-agree.md
+++ b/.changeset/rare-seahorses-agree.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+Remove usage of `@global.Azure.Core.nextLink` as it is been removed

--- a/packages/cadl-ranch-specs/http/azure/core/page/main.tsp
+++ b/packages/cadl-ranch-specs/http/azure/core/page/main.tsp
@@ -142,7 +142,7 @@ model CustomPageModel<T> {
   @doc("List of items.")
   items: T[];
 
-  @global.Azure.Core.nextLink
+  @nextLink
   @doc("Link to fetch more items.")
   nextLink?: string;
 }


### PR DESCRIPTION
Fixing breaking change caused by: https://github.com/Azure/typespec-azure/pull/1886
# Cadl Ranch Contribution Checklist:

- [x] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [x] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [x] I have written a [mock API](../docs/writing-mock-apis.md)
- [x] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
