### PR TITLE
Add Rust to client naming scenarios

### DIFF
--- a/.changeset/loud-cooks-know.md
+++ b/.changeset/loud-cooks-know.md
@@ -1,0 +1,5 @@
+---
+"@azure-tools/cadl-ranch-specs": patch
+---
+
+added Rust to client naming tests

--- a/packages/cadl-ranch-specs/http/client/naming/main.tsp
+++ b/packages/cadl-ranch-specs/http/client/naming/main.tsp
@@ -21,6 +21,7 @@ namespace Property {
     @clientName("JavaName", "java")
     @clientName("TSName", "javascript")
     @clientName("python_name", "python")
+    @clientName("rustName", "rust")
     defaultName: boolean;
   }
 
@@ -150,6 +151,7 @@ namespace Model {
   @clientName("JavaModel", "java")
   @clientName("TSModel", "javascript")
   @clientName("PythonModel", "python")
+  @clientName("rustModel", "rust")
   model ModelWithLanguageClientName {
     @doc("Pass in true")
     defaultName: boolean;


### PR DESCRIPTION
# Cadl Ranch Contribution Checklist:

- [ ] I have written a [scenario spec](../docs/writing-scenario-spec.md)
- [ ] I have **meaningful** `@scenario` names. Someone can look at the list of scenarios and understand what I'm covering.
- [ ] I have written a [mock API](../docs/writing-mock-apis.md)
- [ ] I have used `@scenarioDoc`s for extra scenario description and to tell people **how to pass** my mock api check.
