### PR TITLE
Update readme to add the disclaimer of not creating new PRs and issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Cadl Ranch
 
+# Disclaimer
+
+**Please do not create issues or pull requests in this repository.** 
+
+For any inquiries, please contact us directly at azsdk-dpgdevs@microsoft.com.
+
 ## Requirements
 
 - Node 16+

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 # Disclaimer
 
-**Please do not create issues or pull requests in this repository.** 
+**Please do not create issues or pull requests in this repository.**
+
+If you are looking to contribute or need support, please use our active repository https://github.com/microsoft/typespec.
 
 For any inquiries, please contact us directly at azsdk-dpgdevs@microsoft.com.
 


### PR DESCRIPTION
As we completed the migration of cadl-ranch into spector, all new changes or issues should be created in microsoft/typespec repo and azure case should be added into typespec-azure repo.

Update the readme to add this disclaimer to suggest people not creating new PRs and issues in this repo.  